### PR TITLE
Course intro notebook

### DIFF
--- a/intro/course_intro.ipynb
+++ b/intro/course_intro.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:afd539e202b1d021c1a136f7de2f95d9fbaf4ced807d33e848e9dd3e389f3b2b"
+  "signature": "sha256:d5d7cbafd45480d905e34f730729daf78bf740172fae768e4ff55e5b158fbc04"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -26,15 +26,18 @@
       "<ul>\n",
       "<li>\n",
       "Copy the course content into a relevant location in your Linux homespace (indicated by `.` here):<br />\n",
-      "`$ cp -r ~dkillick/Documents/teaching/scitools_courses .`<br /><br />\n",
+      "<pre><span style=\"color:blue\">$ cp -r ~dkillick/courses_scitools .</span></pre>\n",
+      "\n",
       "</li>\n",
       "<li>\n",
-      "Change to the `course content` directory in the directory you just copied:<br />\n",
-      "`$ cd scitools_courses/course_content`<br /><br />\n",
+      "Change to the `scitools_courses` directory in the directory you just copied:<br />\n",
+      "<pre><span style=\"color:blue\">$ cd scitools_courses</span></pre>\n",
+      "\n",
       "</li>\n",
       "<li>\n",
       "Start the IPython notebook, being sure to include the matplotlib inline flag:<br />\n",
-      "`$ ipython notebook --matplotlib=inline`\n",
+      "<pre><span style=\"color:blue\">$ ipython notebook --matplotlib=inline</span></pre>\n",
+      "\n",
       "</li>\n",
       "</ul>"
      ]
@@ -57,13 +60,13 @@
       "<th>&nbsp;</th><th>AM</th><th>PM</th>\n",
       "</tr>\n",
       "<tr>\n",
-      "<td>Mon</td><td>NumPy</td><td>NumPy / matplotlib</td>\n",
+      "<td>Wed</td><td>NumPy</td><td>NumPy / matplotlib</td>\n",
       "</tr>\n",
       "<tr>\n",
-      "<td>Tue</td><td>matplotlib/cartopy</td><td>Iris</td>\n",
+      "<td>Thur</td><td>matplotlib / cartopy</td><td>Iris</td>\n",
       "</tr>\n",
       "<tr>\n",
-      "<td>Wed</td><td>Iris</td><td>Iris</td>\n",
+      "<td>Fri</td><td>Iris</td><td>Iris</td>\n",
       "</tr>\n",
       "</table>"
      ]
@@ -76,9 +79,31 @@
       "\n",
       "Your teachers on the SciTools courses will be:\n",
       "\n",
-      " * **Peter Killick**\n",
       " * **Laura Dreyer**\n",
-      " * **Patrick Peglar**"
+      " * **Peter Killick**"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Other business ##\n",
+      "\n",
+      "For your information...\n",
+      "<br/><br/>\n",
+      "\n",
+      "<li>\n",
+      "We will do our best to answer any questions you may have during the SciTools courses. If you have any further Python-related questions, please feel free to email us on the AVD Support email address:\n",
+      "\n",
+      "<pre><span style=\"color:green\">ml-avd-support@metoffice.gov.uk</span></pre>\n",
+      "\n",
+      "</li>\n",
+      "<li>\n",
+      "You may get an error when you try to launch Firefox. This is probably because you already have an instance of Firefox running on the machine you normally work on. To get around this, run the following command from the command-line and use the GUI to create a new Firefox profile to use on the machine here:\n",
+      "\n",
+      "<pre><span style=\"color:green\">$ firefox -p</span></pre>\n",
+      "\n",
+      "</li>\n"
      ]
     }
    ],

--- a/intro/course_intro.ipynb
+++ b/intro/course_intro.ipynb
@@ -1,0 +1,88 @@
+{
+ "metadata": {
+  "name": "",
+  "signature": "sha256:afd539e202b1d021c1a136f7de2f95d9fbaf4ced807d33e848e9dd3e389f3b2b"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "# Welcome to the SciTools Courses! #"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Getting the course content ##\n",
+      "\n",
+      "To gain access to a copy of the IPython Notebooks that contain the course material we'll be teaching you from over the next few days, follow the steps below. The command to run each step below is provided in the next cell down.\n",
+      "\n",
+      "<ul>\n",
+      "<li>\n",
+      "Copy the course content into a relevant location in your Linux homespace (indicated by `.` here):<br />\n",
+      "`$ cp -r ~dkillick/Documents/teaching/scitools_courses .`<br /><br />\n",
+      "</li>\n",
+      "<li>\n",
+      "Change to the `course content` directory in the directory you just copied:<br />\n",
+      "`$ cd scitools_courses/course_content`<br /><br />\n",
+      "</li>\n",
+      "<li>\n",
+      "Start the IPython notebook, being sure to include the matplotlib inline flag:<br />\n",
+      "`$ ipython notebook --matplotlib=inline`\n",
+      "</li>\n",
+      "</ul>"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Course layout ##\n",
+      "\n",
+      "We plan to run the courses to approximately the following schedule:"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "<table>\n",
+      "<tr>\n",
+      "<th>&nbsp;</th><th>AM</th><th>PM</th>\n",
+      "</tr>\n",
+      "<tr>\n",
+      "<td>Mon</td><td>NumPy</td><td>NumPy / matplotlib</td>\n",
+      "</tr>\n",
+      "<tr>\n",
+      "<td>Tue</td><td>matplotlib/cartopy</td><td>Iris</td>\n",
+      "</tr>\n",
+      "<tr>\n",
+      "<td>Wed</td><td>Iris</td><td>Iris</td>\n",
+      "</tr>\n",
+      "</table>"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "## Course teachers ##\n",
+      "\n",
+      "Your teachers on the SciTools courses will be:\n",
+      "\n",
+      " * **Peter Killick**\n",
+      " * **Laura Dreyer**\n",
+      " * **Patrick Peglar**"
+     ]
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}


### PR DESCRIPTION
Proposal: when physically teaching the SciTools courses, we need to supply a whole load of introduction instructions for delegates to grab a copy of the course content etc. This new notebook contains that information, as well as an overview of the timings of the courses and the names of the course teachers.

Of course this information would need to be updated each time we physically teach the courses, but that could be done in a local copy of this repo, rather than with successive updates to the repo copy.

Thoughts?