### PR TITLE
Correct image sources

### DIFF
--- a/course_content/notebooks/iris_intro.ipynb
+++ b/course_content/notebooks/iris_intro.ipynb
@@ -84,7 +84,7 @@
       "\n",
       "Suppose we have a ``(3, 2, 4)`` NumPy array:\n",
       "\n",
-      "![](../files/images/multi_array.png)\n"
+      "![](../images/multi_array.png)\n"
      ]
     },
     {
@@ -120,7 +120,7 @@
      "source": [
       "Pictorially the cube has taken on more information than a simple array:\n",
       "\n",
-      "![](../files/images/multi_array_to_cube.png)"
+      "![](../images/multi_array_to_cube.png)"
      ]
     },
     {

--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -1479,7 +1479,7 @@
      "source": [
       "Pictorially:\n",
       "\n",
-      "![Illustration of broadcasting](../files/images/fig_broadcast_visual_1.png)\n",
+      "![Illustration of broadcasting](../images/fig_broadcast_visual_1.png)\n",
       "\n",
       "([image source](http://www.astroml.org/book_figures/appendix/fig_broadcast_visual.html))"
      ]
@@ -1957,7 +1957,7 @@
       "the trapezoid created by linearly interpolating between the two function values\n",
       "at each end of the subinterval:\n",
       "\n",
-      "![Illustration of the trapezoidal rule](../files/images/trapezoidal_rule.png)"
+      "![Illustration of the trapezoidal rule](../images/trapezoidal_rule.png)"
      ]
     },
     {

--- a/make.sh
+++ b/make.sh
@@ -16,9 +16,8 @@ cd html
 for name in "numpy_intro" "matplotlib_intro" "cartopy_intro" "iris_intro"
 do
     #ipython nbconvert --to slides ../../course_content/${name}.ipynb
-    # Build static (html) copies of the course content and deal with an issue where `../files` is being prepended to some img tag src attributes.
+    # Build static (html) copies of the course content.
     jupyter nbconvert --to html ../../course_content/notebooks/${name}.ipynb
-    sed -i 's/<img src=\"..\/files/<img src=\"../' ${name}.html
     # Make IPython notebooks of the course content with cell output cleared.
     python ../../utils/nbutil.py ../../course_content/notebooks/${name}.ipynb ../notebooks/${name}.ipynb --clear-output
 done

--- a/make.sh
+++ b/make.sh
@@ -16,8 +16,9 @@ cd html
 for name in "numpy_intro" "matplotlib_intro" "cartopy_intro" "iris_intro"
 do
     #ipython nbconvert --to slides ../../course_content/${name}.ipynb
-    # Build static (html) copies of the course content.
+    # Build static (html) copies of the course content and deal with an issue where `../files` is being prepended to some img tag src attributes.
     jupyter nbconvert --to html ../../course_content/notebooks/${name}.ipynb
+    sed -i 's/<img src=\"..\/files/<img src=\"../' ${name}.html
     # Make IPython notebooks of the course content with cell output cleared.
     python ../../utils/nbutil.py ../../course_content/notebooks/${name}.ipynb ../notebooks/${name}.ipynb --clear-output
 done


### PR DESCRIPTION
Deal with image sources in static html output by stripping `../files` from `<img>` tags by streaming the html output through a sed command.

This issue occurs when the `<img>` tag has been generated from a local image added to the notebook being converted. In the notebook this is referred to with a relative filepath of style `../files/path/to/img.png`, which is duplicated into the html. While this path works in the notebook it does not work in the html, due to the `files/` element of the path. The sed command introduced here strips out this section of the filepath, leaving `../path/to/img.png`.