### PR TITLE
Common styling for exercises

### DIFF
--- a/course_content/notebooks/iris_intro.ipynb
+++ b/course_content/notebooks/iris_intro.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:80d873097b6d27fde5200b74a51082488d7cb6e820eec8f284105675246dc0df"
+  "signature": "sha256:fc135e3ed020f971bdeed7597ea2d8114b1c966fcc74f3e6b1ed55e87e435e24"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -656,7 +656,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "## Exercise 1:\n",
+      "### Exercise 1\n",
       "\n",
       "1\\. Using the file in ``iris.sample_data_path('atlantic_profiles.nc')`` load the data and print the cube list. Store these cubes in a variable called cubes."
      ]
@@ -790,12 +790,18 @@
      "source": [
       "#### Note on sample_data_path:\n",
       "\n",
-      "Throughout this course we will make use of the sample data that Iris provides. The function ``iris.sample_data_path`` returns the appropriate path to the file in the Iris sample data collection. A common mistake for Iris users is to use the ``sample_data_path`` function to access data that is not part of Iris's sample data collection - this is bad practice and is unlikely to work in the future.\n",
+      "Throughout this course we will make use of the sample data that Iris provides. The function ``iris.sample_data_path`` returns the appropriate path to the file in the Iris sample data collection. A common mistake for Iris users is to use the ``sample_data_path`` function to access data that is not part of Iris's sample data collection - this is bad practice and is unlikely to work in the future."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Exercise 2\n",
       "\n",
-      "**Exercise 2:**\n",
       "Print the result of ``iris.sample_data_path('uk_hires.pp')`` to verify that it returns a string pointing to a file on your system. Use this string directly in the call to ``iris.load`` and confirm the result is the same as in the previous example e.g.:\n",
       "\n",
-      "    print iris.load('/path/to/iris/sampledata/uk_hires.pp', 'air_potential_temperature')\n"
+      "    print iris.load('/path/to/iris/sampledata/uk_hires.pp', 'air_potential_temperature')"
      ]
     },
     {
@@ -857,9 +863,16 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "The load functions all accept a list of filenames to load, and any of the filenames can be \"glob\" patterns (http://docs.python.org/2/library/glob.html).\n",
+      "The load functions all accept a list of filenames to load, and any of the filenames can be \"glob\" patterns (http://docs.python.org/2/library/glob.html)."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Exercise 2 (continued)\n",
       "\n",
-      "**Exercise 2 continued:** Read in the files found at **``iris.sample_data_path('GloSea4', 'ensemble_010.pp')``** and\n",
+      "Read in the files found at **``iris.sample_data_path('GloSea4', 'ensemble_010.pp')``** and\n",
       "**``iris.sample_data_path('GloSea4', 'ensemble_011.pp')``** using a single load call. Do this by:\n",
       "\n",
       "1\\. providing a list of the two filenames."
@@ -1222,14 +1235,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**Exercise 3:**\n",
+      "### Exercise 3\n",
       "\n",
-      "1\\. The following function tells us whether or not a cube has cell methods:\n",
+      "The following function tells us whether or not a cube has cell methods:\n",
       "\n",
       "    def has_cell_methods(cube):\n",
       "        return len(cube.cell_methods) > 0\n",
       "\n",
-      "With the cubes loaded from ``[iris.sample_data_path('A1B_north_america.nc'), iris.sample_data_path('uk_hires.pp')]`` use the CubeList's **``extract``** method to filter only the cubes that have cell methods. (Hint: Look at the ``iris.Constraint`` documentation for the **cube_func** keyword). You should find that the 3 cubes are whittled down to just 1."
+      "1\\. With the cubes loaded from ``[iris.sample_data_path('A1B_north_america.nc'), iris.sample_data_path('uk_hires.pp')]`` use the CubeList's **``extract``** method to filter only the cubes that have cell methods. (Hint: Look at the ``iris.Constraint`` documentation for the **cube_func** keyword). You should find that the 3 cubes are whittled down to just 1."
      ]
     },
     {
@@ -1746,7 +1759,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**1\\.** Identify and resolve the issue preventing ``resources/merge_exercise.1.*.nc`` from merging.\n",
+      "1\\. Identify and resolve the issue preventing ``resources/merge_exercise.1.*.nc`` from merging.\n",
       "\n",
       "    >>> raw_cubes = iris.load_raw('../resources/merge_exercise.1.*.nc')\n",
       "    >>> raw_cubes.merge_cube()\n",
@@ -1791,7 +1804,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**2\\.** Identify and resolve the issue preventing ``resources/merge_exercise.2.*.nc`` from merging.\n",
+      "2\\. Identify and resolve the issue preventing ``resources/merge_exercise.2.*.nc`` from merging.\n",
       "\n",
       "    >>> raw_cubes = iris.load_raw('../resources/merge_exercise.2.*.nc')\n",
       "    >>> raw_cubes.merge_cube()\n",
@@ -1813,7 +1826,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**3\\.** (extension) Identify and resolve the issue preventing ``resources/merge_exercise.4.*.nc`` from merging.\n",
+      "3\\. (extension) Identify and resolve the issue preventing ``resources/merge_exercise.4.*.nc`` from merging.\n",
       "\n",
       "    >>> raw_cubes = iris.load_raw('../resources/merge_exercise.4.*.nc')\n",
       "    >>> raw_cubes.merge_cube()\n",
@@ -1835,7 +1848,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**4\\.** (extension) Identify and resolve the issue preventing ``resources/merge_exercise.5.*.nc`` from merging (hint: Cubes can be indexed like NumPy arrays).\n",
+      "4\\. (extension) Identify and resolve the issue preventing ``resources/merge_exercise.5.*.nc`` from merging (hint: Cubes can be indexed like NumPy arrays).\n",
       "\n",
       "    >>> raw_cubes = iris.load_raw('../resources/merge_exercise.5.*.nc')\n",
       "    >>> raw_cubes.merge_cube()\n",
@@ -2247,7 +2260,7 @@
      "source": [
       "### Exercise 5 ###\n",
       "\n",
-      "**1.** What other aggregators are available?"
+      "1\\. What other aggregators are available?"
      ]
     },
     {
@@ -2263,7 +2276,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**2.** Calculate the potential temperature variance with time for cube `area_avg` from above. Hint: We want to reduce the area averaged cube's vertical dimension, and end up with a cube of length 3. Print the data values of the resulting cube."
+      "2\\. Calculate the potential temperature variance with time for cube `area_avg` from above. Hint: We want to reduce the area averaged cube's vertical dimension, and end up with a cube of length 3. Print the data values of the resulting cube."
      ]
     },
     {
@@ -2654,7 +2667,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "**Exercise 6:** Use the above cube with appropriate slicing, to produce the following:\n",
+      "### Exercise 6\n",
+      "\n",
+      "Use the above cube with appropriate slicing, to produce the following:\n",
       "\n",
       "1\\. a **contour** plot of *time* vs *longitude*"
      ]
@@ -3229,9 +3244,13 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "## Exercise 7\n",
+      "### Exercise 7\n",
       "\n",
-      "1. Load 'A1B_north_america.nc' from the Iris sample data."
+      "Produce a set of plots that provide a comparison of decadal-mean air temperatures over North America:\n",
+      "\n",
+      "**Part 1**\n",
+      "\n",
+      "Load 'A1B_north_america.nc' from the Iris sample data."
      ]
     },
     {
@@ -3247,7 +3266,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "2\\. Extract just data from the year 1980 and beyond from the loaded data."
+      "**Part 2**\n",
+      "\n",
+      "Extract just data from the year 1980 and beyond from the loaded data."
      ]
     },
     {
@@ -3263,7 +3284,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "3\\. Define a function that takes a coordinate and a single time point as arguments, and returns the decade. For example, your function should return 2010 for the following:\n",
+      "**Part 3**\n",
+      "\n",
+      "Define a function that takes a coordinate and a single time point as arguments, and returns the decade. For example, your function should return 2010 for the following:\n",
       "\n",
       "       time = iris.coords.DimCoord([10], 'time',\n",
       "                                   units='days since 2018-01-01')\n",
@@ -3283,7 +3306,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "4\\. Add a \"decade\" coordinate to the loaded cube using your function and the coord categorisation module."
+      "**Part 4**\n",
+      "\n",
+      "Add a \"decade\" coordinate to the loaded cube using your function and the coord categorisation module."
      ]
     },
     {
@@ -3299,7 +3324,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "5\\. Calculate the decadal means cube for this scenario."
+      "**Part 5**\n",
+      "\n",
+      "Calculate the decadal means cube for this scenario."
      ]
     },
     {
@@ -3315,7 +3342,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "6\\. Create a figure with 3 rows and 4 columns displaying the decadal means, with the decade displayed prominently in each axes' title."
+      "**Part 6**\n",
+      "\n",
+      "Create a figure with 3 rows and 4 columns displaying the decadal means, with the decade displayed prominently in each axes' title."
      ]
     },
     {

--- a/course_content/notebooks/matplotlib_intro.ipynb
+++ b/course_content/notebooks/matplotlib_intro.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:b02ee9ce55fc4b16d7e37760f3d7b53edf0c1ef5df9fa62d4d3d58c1b4a92744"
+  "signature": "sha256:a768e94dcfbc500ec6e8a07d9c9c11d132cd5cba5a287a0edc153ff6d82628e2"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -99,12 +99,18 @@
      "source": [
       "Matplotlib's ``pyplot`` module makes the process of creating graphics easier by allowing us to skip some of the tedious Artist construction. For example, we did not need to manually create the Figure artist with ``plt.figure`` because it was implicit that we needed a figure when we created the Axes artist.\n",
       "\n",
-      "Under the hood matplotlib still had to create a Figure artist; we just didn't need to capture it into a variable. We can access the created object with the \"state\" functions found in pyplot called **``gcf``** and **``gca``**.\n",
+      "Under the hood matplotlib still had to create a Figure artist; we just didn't need to capture it into a variable. We can access the created object with the \"state\" functions found in pyplot called **``gcf``** and **``gca``**."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Exercise 1\n",
       "\n",
-      "**Exercise 1:**\n",
+      "Go to matplotlib.org and search for what these strangely named functions do.\n",
       "\n",
-      " * Go to matplotlib.org and search for what these strangely named functions do.\n",
-      "   You will find multiple results so remember we are looking for the ``pyplot`` versions of these functions."
+      "Hint: you will find multiple results so remember we are looking for the ``pyplot`` versions of these functions."
      ]
     },
     {
@@ -152,13 +158,23 @@
      "metadata": {},
      "source": [
       "Notice how the axes view limits (``ax.viewLim``) have been updated to include the whole of the line.\n",
-      "Should we want to add some spacing around the edges of our axes we could set the axes margin using the Axes artist's [``margins``](http://matplotlib.org/api/axes_api.html?highlight=axes#matplotlib.axes.Axes.margins) method. Alternatively, we could manually set the limits with the Axes artist's [``set_xlim``](http://matplotlib.org/api/axes_api.html?#matplotlib.axes.Axes.set_xlim) and [``set_ylim``](http://matplotlib.org/api/axes_api.html?#matplotlib.axes.Axes.set_ylim) methods.\n",
+      "Should we want to add some spacing around the edges of our axes we could set the axes margin using the Axes artist's [``margins``](http://matplotlib.org/api/axes_api.html?highlight=axes#matplotlib.axes.Axes.margins) method. Alternatively, we could manually set the limits with the Axes artist's [``set_xlim``](http://matplotlib.org/api/axes_api.html?#matplotlib.axes.Axes.set_xlim) and [``set_ylim``](http://matplotlib.org/api/axes_api.html?#matplotlib.axes.Axes.set_ylim) methods."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Exercise 2\n",
       "\n",
-      "------\n",
-      "\n",
-      "**Exercise 2:** Modify the previous example to produce three different figures that control the limits of the axes by:\n",
-      "\n",
-      "1\\. Manually setting the x and y limits to $[0.5, 2]$ and $[1, 5]$ respectively."
+      "Modify the previous example to produce three different figures that control the limits of the axes."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "1\\. Manually set the x and y limits to $[0.5, 2]$ and $[1, 5]$ respectively."
      ]
     },
     {
@@ -174,7 +190,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "  2\\. Defining a margin such that there is 10% whitespace inside the axes around the drawn line (Hint: numbers to margins are normalised such that 0% is 0.0 and 100% is 1.0)."
+      "  2\\. Define a margin such that there is 10% whitespace inside the axes around the drawn line (Hint: numbers to margins are normalised such that 0% is 0.0 and 100% is 1.0)."
      ]
     },
     {
@@ -190,7 +206,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "3\\. Setting a 10% margin on the axes with the lower y limit set to 0. (Note: order is important here)"
+      "3\\. Set a 10% margin on the axes with the lower y limit set to 0. (Note: order is important here)"
      ]
     },
     {
@@ -243,9 +259,9 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "--------\n",
+      "### Exercise 3\n",
       "\n",
-      "**Exercise 3:** By calling ``plot`` multiple times, create a single axes showing the line plots of $y=sin(x)$ and $y=cos(x)$ in the interval $[0, 2\\pi]$ with 200 linearly spaced $x$ samples."
+      "By calling ``plot`` multiple times, create a single axes showing the line plots of $y=sin(x)$ and $y=cos(x)$ in the interval $[0, 2\\pi]$ with 200 linearly spaced $x$ samples."
      ]
     },
     {

--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:3cc7b3d0ddcd3a917528c4967082cab5d070da0c01bc2787fccee30c4590bdbc"
+  "signature": "sha256:5c83eaa4c29585c4404cfd256b8464d6c8b724f0d7baf4c33c6a844a3845f116"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -1634,9 +1634,14 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "### Exercise 1:\n",
-      "\n",
-      "Use ``np.arange`` and ``reshape`` to create the array\n",
+      "### Exercise 1"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "1\\. Use ``np.arange`` and ``reshape`` to create the array\n",
       "\n",
       "    A = [[1 2 3 4]\n",
       "         [5 6 7 8]]"
@@ -1655,8 +1660,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "\n",
-      "Use ``np.array`` to create the array\n",
+      "2\\. Use ``np.array`` to create the array\n",
       "\n",
       "    B = [1 2]"
      ]
@@ -1674,8 +1678,7 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "\n",
-      "Use broadcasting to add ``B`` to ``A`` to create the final array\n",
+      "3\\. Use broadcasting to add ``B`` to ``A`` to create the final array\n",
       "\n",
       "    A + B = [[2  3  4  5]\n",
       "             [7  8  9 10]\n",


### PR DESCRIPTION
While I was preparing #34 I noticed that there isn't a common style for introducing exercises in the four SciTools courses. This PR tackles that and in doing so proposes a common style to adopt for courses exercises.

----

The common style I've proposed here is:

 * All exercises are introduced with "Exercise _n_", as an **h3**, with no trailing colon. For example:

### Exercise 2
 
* If the exercise contains multiple parts, each part should be introduced with the appropriate part number followed by a period (and a forward-slash in the markdown to prevent the markdown being interpreted as an ordered list element). For example:

2\. Description for the part of the exercise here:

* If the exercise is a final exercise (only matplotlib doesn't have one), each part should be introduced by **Part _n_** and a blank line. For example:

**Part 4**

Description for the part of the exercise here:

----

This style has been enforced in all four courses by this PR.