### PR TITLE
Correct single value in NP exercise 2 words

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:b48bc151ce58d59168da9a7348afb007eee4c9ce0d4b27ac7025587118b860e3"
+  "signature": "sha256:3cc7b3d0ddcd3a917528c4967082cab5d070da0c01bc2787fccee30c4590bdbc"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -2008,7 +2008,7 @@
      "source": [
       "#### Part 2\n",
       "\n",
-      "Use indexing (not a for loop) to find the 9 values representing $y_{i}+y_{i-1}$ for $i$ between 1 and 11.\n",
+      "Use indexing (not a for loop) to find the 10 values representing $y_{i}+y_{i-1}$ for $i$ between 1 and 11.\n",
       "\n",
       "Hint: What indexing would be needed to get all but the last element of the 1d array **``y``**. Similarly what indexing would be needed to get all but the first element of a 1d array."
      ]


### PR DESCRIPTION
We recently updated the approach used to define the values used in NP exercise two. This means there are now **11** values that the trapezoidal integral is calculated with. This means there are **10** values representing `x_i` and `x_i-1`, rather than 9 values, as was previously true.

That's all this PR changes.