### PR TITLE
Links for further reading section

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -48,7 +48,8 @@
     "* [Application: Calculations -- Arithmetic and Broadcasting](#arithmetic_and_broadcasting)\n",
     "* [Application: Calculations -- Statistics](#statistics)\n",
     "* [Application: Efficiency](#efficiency)\n",
-    "* [Conclusions](#conclusions)"
+    "* [Conclusions](#conclusions)\n",
+    "* [Further Reading](#further_reading)"
    ]
   },
   {
@@ -1295,51 +1296,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Further Reading <a class=\"anchor\" id=\"further\"></a>\n",
+    "## Further Reading <a class=\"anchor\" id=\"further_reading\"></a>\n",
     "\n",
-    "A quick list of some topics and facilities you probably ought to know about, but we did not have time for\n",
+    "A quick list of some topics and facilities provided by NumPy that you probably ought to know about, but we did not have time for in this workshop.\n",
     "\n",
-    "**TODO:** add clickable links to documentation to all these\n",
+    "### Concepts:\n",
     "\n",
-    "Concepts:\n",
-    "  *  module functions and array methods\n",
-    "  *  masked arrays and missing data\n",
-    "    * \".mask\", \".data\", \".fill_value\", \".filled()\"\n",
-    "    * NaNs and nan-functions ('nanmean', 'nanmax' etc)\n",
-    "    * boolean array indexing\n",
-    "  *  matrix multiply\n",
-    "  *  C and Fortran storage order\n",
-    "  *  file i/o\n",
+    "  * module functions and [array methods](https://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html#array-methods)\n",
+    "  * [masked arrays](https://docs.scipy.org/doc/numpy/reference/maskedarray.generic.html) and missing data:\n",
+    "    * [`masked_array.mask`](https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray.mask), [`masked_array.data`](https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray.data), [`masked_array.fill_value`](https://docs.scipy.org/doc/numpy/reference/maskedarray.baseclass.html#numpy.ma.MaskedArray.fill_value), [`masked_array.filled()`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ma.MaskedArray.filled.html#numpy.ma.MaskedArray.filled)\n",
+    "    * [NaN](https://docs.scipy.org/doc/numpy/user/misc.html)s and NaN functions ([nanmean](https://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.nanmean.html), [nanmax](https://docs.scipy.org/doc/numpy/reference/generated/numpy.nanmax.html#numpy.nanmax) etc.)\n",
+    "    * boolean arrays and [boolean array indexing](https://docs.scipy.org/doc/numpy/user/basics.indexing.html#boolean-or-mask-index-arrays)\n",
+    "  * matrix multiplication (for example using [dot](https://docs.scipy.org/doc/numpy/reference/generated/numpy.dot.html))\n",
+    "  * C and Fortran storage order -- see \"C order\" and \"Fortran order\" in [the glossary](https://docs.scipy.org/doc/numpy/glossary.html)\n",
+    "  * [file I/O](https://docs.scipy.org/doc/numpy/reference/routines.io.html)\n",
     "\n",
-    "Terminology:\n",
-    "  *  ufunc\n",
-    "  *  boolean array\n",
-    "  *  \"fancy\" indexing\n",
+    "### Terminology:\n",
     "\n",
-    "Concrete functions\n",
-    "  *  empty\n",
-    "  *  meshgrid\n",
-    "  *  stack  + concatenate\n",
-    "  *  transpose, \".T\"\n"
+    "  * [ufunc](https://docs.scipy.org/doc/numpy/reference/ufuncs.html)\n",
+    "  * [\"fancy\" indexing](https://docs.scipy.org/doc/numpy/user/basics.indexing.html#index-arrays) (indexing with arrays of indices)\n",
+    "\n",
+    "### Concrete functions:\n",
+    "\n",
+    "  * [empty](https://docs.scipy.org/doc/numpy/reference/generated/numpy.empty.html)\n",
+    "  * [meshgrid](https://docs.scipy.org/doc/numpy/reference/generated/numpy.meshgrid.html)\n",
+    "  * [stack](https://docs.scipy.org/doc/numpy/reference/generated/numpy.stack.html), [concatenate](https://docs.scipy.org/doc/numpy/reference/generated/numpy.concatenate.html#numpy.concatenate) and [split](https://docs.scipy.org/doc/numpy/reference/generated/numpy.split.html#numpy.split)\n",
+    "  * [transpose](https://docs.scipy.org/doc/numpy/reference/generated/numpy.transpose.html) ([`array.T`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.T.html#numpy.ndarray.T))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Adds links to the NumPy docs for the concepts listed in _§Further Reading_ at the end of the workshop material. Replaces #63. 