### PR TITLE
Reduce some header levels

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -919,14 +919,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Efficiency <a class=\"anchor\" id=\"efficiency\"></a>"
+    "## Efficiency <a class=\"anchor\" id=\"efficiency\"></a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loops and Vectorised Operations\n",
+    "### Loops and Vectorised Operations\n",
     "\n",
     "We will now explore calculation performance and consider efficiency in terms of processing time.\n",
     "\n",
@@ -1031,7 +1031,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercise 2: trapezoidal integration,\n",
+    "### Exercise: trapezoidal integration\n",
     "\n",
     "In this exercise, you are tasked with implementing the simple trapezoid rule\n",
     "formula for numerical integration. If we want to compute the definite integral\n",
@@ -1184,7 +1184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Memory Errors\n",
+    "### Memory Errors\n",
     "\n",
     "NumPy can only work with the system memory.  If too large an array is realised, a memory error will result."
    ]
@@ -1207,7 +1207,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Views on Arrays\n",
+    "### Views on Arrays\n",
     "NumPy attempts to not make copies of arrays unless it is explicitly told to.  \n",
     "\n",
     "Many NumPy operations will produce a reference to an existing array, known as a \"view\", instead of making a whole new array.\n",
@@ -1279,7 +1279,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Conclusions <a class=\"anchor\" id=\"conclusions\"></a>"
+    "## Conclusions <a class=\"anchor\" id=\"conclusions\"></a>"
    ]
   },
   {


### PR DESCRIPTION
Any html document may have one `<h1>` tag and one only, for reasons of accessibilty. This removes all `<h1>` tags apart from the first and also reduces any sub-headers under the spurious `<h1>` tags so that consistency of header level is maintained.