### PR TITLE
remove extension, did not flow for participants

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -913,32 +913,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's return to the daily maximum temperature example. Imagine that one day you receive four days' worth of maximum temperature values for the three sites, but for some reason the data are malformed into one long list of values. Nevertheless, you still need to apply the correct offsets to each site's values.\n",
-    "\n",
-    "You can assume that the ordering of the values is the same as in the earlier example. That is, the order is `[day1-station1, day1-station2, day1-station3, day2-station1, ...]` and so on.\n",
-    "\n",
-    "    four_days = [16, 14, 12, 15, 14, 14, 16, 11, 9, 13, 12, 10]\n",
-    "\n",
-    "##### Questions:\n",
-    "\n",
-    " 1. Suppose you want to remove the daily offsets, as before: Use broadcasting and reshape to achieve this.\n",
-    " 2. Suppose the values were supplied in a different order, with adjacent days for each station, i.e. `[day1-station1, day2-station1, day3-station1, day1-station2, day2-station2, day3-station2, ...]`.  Write code to handle this data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now go and play! \n",
+    "Now go and experiment with this behaviour! \n",
     "\n",
     "You could review some of your experiments that failed from the earlier \"Elementwise Arithmetic\" section and see if you can now make them work."
    ]


### PR DESCRIPTION
this example caused problems in the last running of the numpy course

the logic did not quite flow and it ended up confusing rather than illustrating the point

I have just removed it, as the simplest quick solution