### PR TITLE
Add %matplotlib=inline to notebooks with plots.

### DIFF
--- a/course_content/notebooks/cartopy_intro.ipynb
+++ b/course_content/notebooks/cartopy_intro.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/course_content/notebooks/iris_intro.ipynb
+++ b/course_content/notebooks/iris_intro.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/course_content/notebooks/matplotlib_intro.ipynb
+++ b/course_content/notebooks/matplotlib_intro.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
You can't do
$ jupyter notebook --matplotlib=inline 
like you can do with ipython so we need to add the matplotlib magic to make the plots inline

So you can see what it looks like,
Here is matplotlib:
![matplotlib](https://cloud.githubusercontent.com/assets/8101163/26243052/6d5bc448-3c82-11e7-886e-d8f612e6e63e.png)
Here is cartopy:
![cartopy](https://cloud.githubusercontent.com/assets/8101163/26243078/85768ff4-3c82-11e7-9968-ef0c4f40f7b0.png)
Here is iris:
![iris](https://cloud.githubusercontent.com/assets/8101163/26243095/8c27859c-3c82-11e7-85cf-610c51e96930.png)
