### PR TITLE
[NumPy] Shorten statistics section

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -948,7 +948,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Statistics <a class=\"anchor\" id=\"statistics\"></a>\n",
+    "### Statistics and Masked Arrays <a class=\"anchor\" id=\"statistics\"></a>\n",
+    "\n",
+    "#### Statistics\n",
     "\n",
     "Numpy arrays support many common statistical calculations. For a list of common operations, see : https://docs.scipy.org/doc/numpy/reference/routines.statistics.html.\n",
     "\n",
@@ -973,41 +975,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Exercise \n",
-    "\n",
-    " * What is the mean value over all the values in our `daily_records` array, given by the `np.mean()` function ?\n",
-    " * What other similar statistical operations exist (see above link) ?\n",
-    " * A mean value can also be calculated with `<array>.mean()`.  Is that the same thing ?\n",
-    " * How should you calculate a median value -- with `np.median(array)` or `array.median()` ?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Used without any further arguments, statistical functions simply reduce the whole array to a single value.  In practice, however, we very often want to calculate statistics over only *some* of the dimensions.\n",
     "\n",
     "The most common requirement is to calculate a statistic along a single array dimension, while leaving all the other dimensions intact.   This is referred to as \"collapsing\" or \"reducing\" the chosen dimension.\n",
@@ -1022,12 +989,12 @@
     " [11 12 15]]\n",
     "```\n",
     "\n",
-    "For this data, by adding the `axis` keyword, we can calculate either :\n",
-    "  * (a) `axis=0` : a statistic **over both days, for each station** , or\n",
-    "  * (b) `axis=1` : a statistic **over all three stations, for each day**.\n",
+    "For this data, by adding the `axis` keyword, we can calculate either...\n",
+    "  * using `axis=0`: a statistic **over both days, for each station**, or\n",
+    "  * using `axis=1`: a statistic **over all three stations, for each day**.\n",
     "\n",
-    "For most statistical functions (but not all), the \"axis\" keyword will also accept multiple dimensions, e.g. ```axis=(0, 2)```.  \n",
-    "Remember also that the *default* statistical operation, as seen above, is to collapses over _all_ dimensions, reducing the array to a single value.  This is equivalent to coding ```axis=None```."
+    "For most statistical functions (but not all), the \"axis\" keyword will also accept multiple dimensions, e.g. `axis=(0, 2)`.  \n",
+    "Remember also that the *default* statistical operation, as seen above, is to collapses over _all_ dimensions, reducing the array to a single value.  This is equivalent to specifying `axis=None`."
    ]
   },
   {
@@ -1036,10 +1003,11 @@
    "source": [
     "#### Exercise \n",
     "\n",
+    "* What other similar statistical operations exist (see above link) ?\n",
+    "* A mean value can also be calculated with `<array>.mean()`.  Is that the same thing ?\n",
     "* produce the two kinds of single-axis average mentioned above -- that is:\n",
     "   1. over all days at each station, \n",
-    "   2. over all stations for each day. \n",
-    "     * (Hint: look at the documentation -- the term 'axis' in NumPy refers to the number of a dimension.)\n",
+    "   2. over all stations for each day.\n",
     "* Create a sample 3-D array, to represent air temperature at given times, X and Y positions :\n",
     "   1. how can you form a mean over all X and Y at each timestep ?  \n",
     "   1. what shape does such result have ?\n",

--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -111,7 +111,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# From a list of specified numbers.\n",
@@ -258,7 +260,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "arr = np.ones((3, 2, 4))\n",
@@ -285,7 +289,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -299,7 +305,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -313,7 +321,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -329,7 +339,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "arr = np.array([1, 2, 3, 4, 5, 6])\n",
@@ -349,7 +361,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "lst_2d = [[1, 2, 3], [4, 5, 6]]\n",
@@ -459,7 +473,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -480,7 +496,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -501,7 +519,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(lst_2d[0:2][1])\n",
@@ -591,7 +611,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "arr1 = np.arange(4)\n",
@@ -612,21 +634,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -640,7 +668,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "arr = np.arange(4)\n",
@@ -665,7 +695,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "daily_records = np.array([[12, 14, 11], [11, 12, 15]])\n",
@@ -687,6 +719,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "internals": {
      "slide_helper": "subslide_end"
     },
@@ -772,7 +805,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "arr1 = np.ones((2, 3))\n",
@@ -844,7 +879,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "days_adjust = np.array([1.5, 3.7])\n",
@@ -919,7 +956,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -948,9 +987,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Statistics and Masked Arrays <a class=\"anchor\" id=\"statistics\"></a>\n",
+    "## Application: Statistics and Masked Arrays <a class=\"anchor\" id=\"statistics\"></a>\n",
     "\n",
-    "#### Statistics\n",
+    "### Statistics\n",
     "\n",
     "Numpy arrays support many common statistical calculations. For a list of common operations, see : https://docs.scipy.org/doc/numpy/reference/routines.statistics.html.\n",
     "\n",
@@ -962,7 +1001,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a = np.arange(12).reshape((3, 4))\n",
@@ -1046,7 +1087,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Masked Arrays\n",
+    "### Masked Arrays\n",
     "\n",
     "Real-world measurements processes often result in certain datapoint values being uncertain or simply \"missing\".  This is usually indicated by additional data quality information, stored alongside the data values.\n",
     "\n",
@@ -1059,7 +1100,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "daily_records = np.array([[12, 14, 11], [11, 12, 15]])\n",
@@ -1079,7 +1122,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print('unmasked average = ', np.mean(daily_records))\n",
@@ -1232,7 +1277,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%timeit \n",
@@ -1249,7 +1296,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%timeit -n 100 -r 5\n",
@@ -1266,7 +1315,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "rands = np.random.random(1000000).reshape(100, 100, 100)"
@@ -1275,7 +1326,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%timeit -n 10 -r 5\n",
@@ -1290,7 +1343,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%timeit -n 10 -r 5\n",


### PR DESCRIPTION
Shorten the statistics section of the NumPy course, primarily by removing the first, and largely excessive, exercise. The key points of this exercise are ported into the final exercise in the section on Statistics, which is now the only exercise in this section.