### PR TITLE
[NumPy] Reinstate section on meshgrid

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -77,9 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# NumPy is generally imported as 'np'.\n",
@@ -583,12 +581,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Generating 2D coordinate arrays\n",
+    "\n",
+    "A common requirement of NumPy arrays is to generate arrays that represent the coordinates of our data.\n",
+    "\n",
+    "When orthogonal 1d coordinate arrays already exist, NumPy's meshgrid function is very useful:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(0, 9, 3)\n",
+    "y = np.linspace(4, 8, 3)\n",
+    "x2d, y2d = np.meshgrid(x, y)\n",
+    "print x2d\n",
+    "print y2d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### The Array Object: Summary of key  points\n",
     " * properties : `shape`, `dtype`\n",
     " * arrays are homogeneous, all elements have the same type: `dtype`\n",
     " * creation : `array([list])`, `ones`, `zeros`, `arange`, `linspace`:\n",
     "  * indexing arrays to produce further arrays: views on the original arrays\n",
     "  * multi-dimensional indexing and conditional indexing\n",
+    "\n",
+    " * combinations to form 2D arrays: `meshgrid`\n",
     " "
    ]
   },


### PR DESCRIPTION
Reinstates the section on the NumPy functionality `meshgrid` from the original NumPy course as `meshgrid` is required teaching of this course: it's used in the cartopy exercise.