### PR TITLE
[cartopy] Add item on subplots

### DIFF
--- a/course_content/notebooks/cartopy_intro.ipynb
+++ b/course_content/notebooks/cartopy_intro.ipynb
@@ -30,7 +30,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -66,13 +68,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To draw cartographic data, we use the the standard matplotlib plotting routines with an additional **transform** keyword argument. The value of the **transform** argument should be the cartopy coordinate reference system *of the data being plotted*:"
+    "Let's compare the Plate Carree projection to another projection from the projection list; being the Miller projection. We'll do that by plotting two subplots next to each other at the same time:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the figure is a decent size when plotted.\n",
+    "fig = plt.figure(figsize=(14, 7))\n",
+    "\n",
+    "# Upper plot.\n",
+    "ax1 = fig.add_subplot(1, 2, 1, projection=ccrs.PlateCarree())\n",
+    "ax1.coastlines()\n",
+    "\n",
+    "# Lower plot.\n",
+    "ax2 = fig.add_subplot(1, 2, 2, projection=ccrs.Miller())\n",
+    "ax2.coastlines()\n",
+    "\n",
+    "# Show both subplots on the same figure.\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To draw cartographic data, we use the standard matplotlib plotting routines with an additional **transform** keyword argument. The value of the **transform** argument should be the cartopy coordinate reference system *of the data being plotted*:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ax = plt.axes(projection=ccrs.PlateCarree())\n",
@@ -99,7 +131,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ax = plt.axes(projection=ccrs.Mercator())\n",
@@ -118,7 +152,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.ticker as mticker\n",
@@ -153,7 +189,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -179,7 +217,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -195,7 +235,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -211,7 +253,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
One of the pre-course requests from the target learners of the one-day course is an item on how to use matplotlib subplots. This adds a short section demonstrating using subplots within the context of comparing multiple cartopy map projections.