### PR TITLE
[cartopy] Aims, objectives and section headings

### DIFF
--- a/course_content/notebooks/cartopy_intro.ipynb
+++ b/course_content/notebooks/cartopy_intro.ipynb
@@ -47,7 +47,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -64,7 +66,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ax = plt.axes(projection=ccrs.PlateCarree())\n",
@@ -83,15 +87,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Transforming data\n",
-    "\n",
-    "To draw cartographic data, we use the the standard matplotlib plotting routines with an additional **`transform`** keyword argument. The value of the `transform` argument should be the cartopy coordinate reference system *of the data being plotted*:"
+    "Let's compare the Plate Carree projection to another projection from the projection list; being the Miller projection. We'll do that by plotting two subplots next to each other at the same time:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Make sure the figure is a decent size when plotted.\n",
@@ -113,7 +117,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To draw cartographic data, we use the standard matplotlib plotting routines with an additional **transform** keyword argument. The value of the **transform** argument should be the cartopy coordinate reference system *of the data being plotted*:"
+    "## Transforming data\n",
+    "\n",
+    "To draw cartographic data, we use the standard matplotlib plotting routines with an additional **`transform`** keyword argument. The value of the `transform` argument should be the cartopy coordinate reference system *of the data being plotted*:"
    ]
   },
   {
@@ -150,7 +156,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ax = plt.axes(projection=ccrs.Mercator())\n",
@@ -169,7 +177,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import matplotlib.ticker as mticker\n",
@@ -196,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercise 1\n",
+    "## Exercise\n",
     "\n",
     "The following snippet of code produces coordinate arrays and some data in a rotated pole coordinate system. The coordinate system for the `x` and `y` values, which is similar to that found in the some limited area models of Europe, has a projection \"north pole\" at 193.0 degrees longitude and 41.0 degrees latitude."
    ]
@@ -204,7 +214,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -230,7 +242,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -246,7 +260,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   },
@@ -262,7 +278,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }

--- a/course_content/notebooks/cartopy_intro.ipynb
+++ b/course_content/notebooks/cartopy_intro.ipynb
@@ -15,7 +15,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Cartopy in a nutshell\n",
+    "# Cartopy in a nutshell\n",
+    "\n",
+    "## Course aims and objectives\n",
+    "\n",
+    "The **aim** of the cartopy course is to introduce the cartopy library and raise awareness of some of its features.\n",
+    "\n",
+    "The **learning outcomes** of the cartopy course are as follows. By the end of the course, you will be able to:\n",
+    "\n",
+    "* understand the functionality provided by the `cartopy.crs` module,\n",
+    "* explain the purpose and usage of the `projection` and `transform` keyword arguments, and\n",
+    "* add geolocated data, grid lines and Natural Earth features to a cartopy map."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction: maps and projections\n",
     "\n",
     "Cartopy is a Python package that provides easy creation of maps, using matplotlib, for the analysis and visualisation of geospatial data."
    ]
@@ -30,9 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -43,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cartopy's matplotlib interface is set up via the `projection` keyword when constructing a matplotlib `Axes` / `SubAxes` instance. The resulting axes instance has new methods, such as the **``coastlines()``** method, which are specific to drawing cartographic data:"
+    "Cartopy's matplotlib interface is set up via the **`projection`** keyword when constructing a matplotlib `Axes` / `SubAxes` instance. The resulting axes instance has new methods, such as the **``coastlines()``** method, which are specific to drawing cartographic data:"
    ]
   },
   {
@@ -68,7 +83,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's compare the Plate Carree projection to another projection from the projection list; being the Miller projection. We'll do that by plotting two subplots next to each other at the same time:"
+    "## Transforming data\n",
+    "\n",
+    "To draw cartographic data, we use the the standard matplotlib plotting routines with an additional **`transform`** keyword argument. The value of the `transform` argument should be the cartopy coordinate reference system *of the data being plotted*:"
    ]
   },
   {
@@ -125,15 +142,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Adding features\n",
+    "\n",
     "We can add graticule lines and tick labels to the map using the gridlines method (this currently is limited to just a few coordinate reference systems):"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ax = plt.axes(projection=ccrs.Mercator())\n",
@@ -152,9 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.ticker as mticker\n",
@@ -189,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -217,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -235,9 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -253,9 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }


### PR DESCRIPTION
Added aims and objectives for the cartopy course to the top of the course. Also added section headings as they made it flow better once the aims and objectives section had been added.

Ping @benclarke18 @sophieallan 