### PR TITLE
[dask] New course link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python courses for the scientific researcher
 This repository contains several courses for the benefit of scientific researchers,
 particularly in the fields of oceanography and meteorology.
 
-There are currently four courses:
+There are currently five courses:
 
 ### An introduction to numpy
 3.5 hours &mdash; depends on a basic Python background
@@ -21,3 +21,7 @@ http://nbviewer.ipython.org/github/SciTools/courses/blob/master/course_content/n
 ### An introduction to Iris
 6 hours &mdash; depends on "Cartopy in a nutshell"
 http://nbviewer.ipython.org/github/SciTools/courses/blob/master/course_content/notebooks/iris_intro.ipynb?create=1
+
+### An introduction to Dask
+3 hours &mdash; depends on "An introduction to Iris"
+http://nbviewer.jupyter.org/github/SciTools/courses/blob/dask_course/course_content/notebooks/dask_intro.ipynb


### PR DESCRIPTION
Add a link to the new dask course notebook as rendered on nbviewer.ipython.org.