### PR TITLE
[Dask] Add section on using map and filter to constrain iris.load

### DIFF
--- a/course_content/notebooks/dask_intro.ipynb
+++ b/course_content/notebooks/dask_intro.ipynb
@@ -114,9 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def add(a, b):\n",
@@ -150,9 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dsk = {'x': 1,\n",
@@ -281,9 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from dask import delayed\n",
@@ -311,9 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "z = add(1, 2)\n",
@@ -323,9 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "z.visualize()"
@@ -334,9 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "z.compute()"
@@ -352,9 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "a = inc(1)\n",
@@ -366,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "c.visualize()"
@@ -377,9 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "c.compute()"
@@ -403,9 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "results = []\n",
@@ -429,9 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -445,9 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -471,9 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import iris\n",
@@ -492,9 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "files = glob.glob(iris.sample_data_path('UM', '*.pp'))"
@@ -503,9 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print('Earliest: {}\\nLatest: {}'.format(files[0], files[-1]))"
@@ -523,9 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cubelist = iris.cube.CubeList(map(iris.load_cube, files))"
@@ -534,9 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "len(cubelist)"
@@ -545,9 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "type(cubelist)"
@@ -565,9 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bag_o_cubes = db.from_sequence(files).map(iris.load_cube)"
@@ -576,9 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "type(bag_o_cubes)"
@@ -587,9 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bag_o_cubes.visualize()"
@@ -607,9 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bag_cubelist = iris.cube.CubeList(bag_o_cubes.compute())"
@@ -618,9 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "len(bag_cubelist)"
@@ -629,9 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "type(bag_cubelist)"
@@ -660,9 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cube = iris.load_cube(files)\n",
@@ -680,9 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "single_cube = iris.load_cube(files[0])\n",
@@ -701,9 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "bag_merged_cube = bag_cubelist.merge_cube()\n",
@@ -721,9 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "@delayed\n",
@@ -745,9 +689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -761,9 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(delayed_merged_cube.compute())"
@@ -786,9 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "filepath = '/project/avd/iris/resources/git/iris-sample-data/sample_data'\n",
@@ -815,9 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "phenom_cubes = iris.load(files, 'air_potential_temperature')\n",
@@ -834,9 +770,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "phen_cstr = ['air_potential_temperature'] * len(files)"
@@ -852,9 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "phenom_dask_load = db.from_delayed(map(delayed(iris.load), files, phen_cstr))"
@@ -870,9 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "phenom_dask_load.visualize()"
@@ -888,9 +818,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "phenom_dask_cubes = phenom_dask_load.compute()\n",
@@ -914,9 +842,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mln_cstr = iris.Constraint(model_level_number=lambda cell: cell < 10)\n",
@@ -933,9 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mln_cubes = iris.load(files, mln_cstr)\n",
@@ -952,9 +876,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mln_dask_load = db.from_delayed(map(delayed(iris.load), files, mln_cstr_list))"
@@ -963,9 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mln_dask_load.visualize()"
@@ -974,9 +894,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "mln_dask_cubes = mln_dask_load.compute()\n",
@@ -1000,9 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "time_cstr = iris.Constraint(time=lambda cell: 1920 <= cell.point.year < 1950)\n",
@@ -1019,9 +935,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with iris.FUTURE.context(cell_datetime_objects=True):\n",
@@ -1039,9 +953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "time_dask_load = db.from_delayed(map(delayed(iris.load), files, time_cstr_list))"
@@ -1050,9 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "time_dask_load.visualize()"
@@ -1061,9 +971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "with iris.FUTURE.context(cell_datetime_objects=True):\n",
@@ -1090,9 +998,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "um_cstr = iris.AttributeConstraint(um_version='7.3')\n",
@@ -1109,9 +1015,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "um_cubes = iris.load(files, um_cstr)\n",
@@ -1128,9 +1032,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "um_dask_load = db.from_delayed(map(delayed(iris.load), files, um_cstr_list))"
@@ -1139,9 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "um_dask_load.visualize()"
@@ -1150,9 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "um_dask_cubes = um_dask_load.compute()\n",
@@ -1163,115 +1061,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercise: Loading\n",
-    "\n",
-    "Consider the following code snippets. Despite looking similar, not all of these code snippets will provide parallel file loading:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# This cell sets up the files needed by the exercise.\n",
-    "filepath = iris.sample_data_path('GloSea4')\n",
-    "files = glob.glob(os.path.join(filepath, '*.pp'))\n",
-    "files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "dlyd = delayed(iris.load)(os.path.join(filepath, '*.pp'))\n",
-    "cs1 = db.from_delayed(dlyd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "cs2 = db.from_sequence(files).map(iris.load_cube)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "cs3 = db.from_delayed(map(delayed(iris.load), files))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**1.** Print the task graph for each code snippet."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**2.** With reference to the task graph produced by each code snippet, state whether or not each code snippet will provide parallel file loading."
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**3.** For the code snippets that do not provide parallel file loading, describe why parallel file loading does not happen and suggest a change to the code snippet to enable parallel file loading."
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Using `filter` as a Constraint for Iris Load with Dask\n",
     "\n",
-    "We have seen how to load a subset of data by passing a `constraint` to `iris.load` when loading from `files`. We have also seen how to do this by passing lists of filenames and constraints to `delayed(iris.load)`, generating a `dask.bag`. Here we will use the `map` and `filter` functionality of `dask.bag` with `iris.load` to subset data using a phenomenon constraint."
+    "We have seen how to load a subset of data by passing a `constraint` to `iris.load` when loading from a list of filenames. We have also seen how to do this by mapping lists of filenames and constraints onto `delayed(iris.load)`, generating a `dask.bag`. Here we will use the `map` and `filter` functionality of `dask.bag` with `iris.load` to subset data using a phenomenon constraint."
    ]
   },
   {
@@ -1280,9 +1072,10 @@
    "source": [
     "First we should define what we mean when we talk about `map` and `filter`:\n",
     "\n",
-    "`map(func, seq)`: A function which takes a function (`func`) and a sequence of inputs (`seq`) as arguments. It returns a sequence of outputs which are the result of applying `func` to each of the items in `seq`.\n",
+    "- `map(func, seq)` <br> A function which takes a callable (`func`) and a sequence of inputs (`seq`) as arguments. It returns a sequence of outputs which are the result of applying `func` to each of the items in `seq`.\n",
     "\n",
-    "`filter(func, seq)`: A function which also takes a function (`func`) and a sequence of inputs (`seq`) as arguments. `func` must be a function which returns a Boolean value, i.e. either `True` or `False`. This function will be applied to every element of `seq` and only if `func` returns `True` will the element of the sequence be included in the output sequence."
+    "\n",
+    "- `filter(func, seq)` <br> A function which also takes a callable (`func`) and a sequence of inputs (`seq`) as arguments. `func` must be a callable which returns a Boolean value, i.e. either `True` or `False`. `func` will be applied to every element of `seq` and only if `func` returns `True` will the element of the sequence be included in the output sequence."
    ]
   },
   {
@@ -1315,14 +1108,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "phenom_filter = lambda cube: cube.name() == 'air_temperature'"
+    "phenom_filter = lambda cube: cube.name() == 'air_potential_temperature'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case we used a `lambda` to define our filter function, which returns `True` if the name of the phenomenon represented by the cube is `'air_temperature'`.\n",
+    "In this case we used a `lambda` to define our filter function, which returns `True` if the name of the phenomenon represented by the cube is `'air_potential_temperature'`.\n",
     "\n",
     "`bag_of_cubes` is a nested list of lists, with each list containing the cubes from each file. We can use `flatten` to reduce it to a single list of cubes then apply `filter` to select cubes based on a phenomenon:"
    ]
@@ -1341,7 +1134,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again we can use the magic of Python to chain this all into one line of code:"
+    "Again Python handily allows us to chain together `from_sequence()`, `map()`, `flatten()`, `filter()` and `compute()` into one long line of code:"
    ]
   },
   {
@@ -1350,8 +1143,104 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filtered_cubes = db.from_sequence(files).map(iris.load).flatten().filter(lambda c: c.name()=='surface_altitude').compute()"
+    "alt_filter = lambda cube: cube.name() == 'surface_altitude'\n",
+    "\n",
+    "db.from_sequence(files).map(iris.load).flatten().filter(alt_filter).compute()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise: Loading\n",
+    "\n",
+    "Consider the following code snippets. Despite looking similar, not all of these code snippets will provide parallel file loading:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This cell sets up the files needed by the exercise.\n",
+    "filepath = iris.sample_data_path('GloSea4')\n",
+    "files = glob.glob(os.path.join(filepath, '*.pp'))\n",
+    "files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dlyd = delayed(iris.load)(os.path.join(filepath, '*.pp'))\n",
+    "cs1 = db.from_delayed(dlyd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cs2 = db.from_sequence(files).map(iris.load_cube)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cs3 = db.from_delayed(map(delayed(iris.load), files))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**1.** Print the task graph for each code snippet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**2.** With reference to the task graph produced by each code snippet, state whether or not each code snippet will provide parallel file loading."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**3.** For the code snippets that do not provide parallel file loading, describe why parallel file loading does not happen and suggest a change to the code snippet to enable parallel file loading."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/course_content/notebooks/dask_intro.ipynb
+++ b/course_content/notebooks/dask_intro.ipynb
@@ -739,7 +739,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once again if you expand the task graph (double-click image) you can see that `merge_cube()` is now part of it. Compare this to the task graph of `bag-o-cubes`. What is different?"
+    "Once again if you expand the task graph (double-click image) you can see that `merge_cube()` is now part of it. Compare this to the task graph of `bag_o_cubes`. What is different?"
    ]
   },
   {
@@ -1264,6 +1264,94 @@
    "cell_type": "raw",
    "metadata": {},
    "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using `filter` as a Constraint for Iris Load with Dask\n",
+    "\n",
+    "We have seen how to load a subset of data by passing a `constraint` to `iris.load` when loading from `files`. We have also seen how to do this by passing lists of filenames and constraints to `delayed(iris.load)`, generating a `dask.bag`. Here we will use the `map` and `filter` functionality of `dask.bag` with `iris.load` to subset data using a phenomenon constraint."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First we should define what we mean when we talk about `map` and `filter`:\n",
+    "\n",
+    "`map(func, seq)`: A function which takes a function (`func`) and a sequence of inputs (`seq`) as arguments. It returns a sequence of outputs which are the result of applying `func` to each of the items in `seq`.\n",
+    "\n",
+    "`filter(func, seq)`: A function which also takes a function (`func`) and a sequence of inputs (`seq`) as arguments. `func` must be a function which returns a Boolean value, i.e. either `True` or `False`. This function will be applied to every element of `seq` and only if `func` returns `True` will the element of the sequence be included in the output sequence."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`filter` sounds very similar to what we were doing when using `iris.load` with a `constraint`. In a similar way to how we generated `bag_o_cubes` we can generate a `dask.bag` by mapping a sequence of filenames onto `iris.load`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bag_of_cubes = db.from_sequence(files).map(iris.load)\n",
+    "bag_of_cubes.compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `filter` function of a `bag_of_cubes` to constrain it based on the phenomenon it represents. To do this we need to define a filter function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phenom_filter = lambda cube: cube.name() == 'air_temperature'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case we used a `lambda` to define our filter function, which returns `True` if the name of the phenomenon represented by the cube is `'air_temperature'`.\n",
+    "\n",
+    "`bag_of_cubes` is a nested list of lists, with each list containing the cubes from each file. We can use `flatten` to reduce it to a single list of cubes then apply `filter` to select cubes based on a phenomenon:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_bag = bag_of_cubes.flatten().filter(phenom_filter)\n",
+    "filtered_bag.compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again we can use the magic of Python to chain this all into one line of code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered_cubes = db.from_sequence(files).map(iris.load).flatten().filter(lambda c: c.name()=='surface_altitude').compute()"
+   ]
   }
  ],
  "metadata": {
@@ -1282,7 +1370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds a section to the dask_intro notebook outlining how to use the `map` and `filter` functionality of `dask.bag` to constrain the cubes loaded using `iris.load` based on a phenomenon.