### PR TITLE
Fix NumPy notebook

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -77,7 +77,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# NumPy is generally imported as 'np'.\n",
@@ -357,7 +359,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "print(\"arr[2] = {}\".format(arr[2]))\n",
@@ -369,7 +373,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also index multidimensional arrays using an enhanced indexing syntax, which allows for multi-element indexing. (Sometimes this is referred to as "extended slicing".) Remember that Python uses zero-based indexing!"
+    "You can also index multidimensional arrays using an enhanced indexing syntax, which allows for multi-element indexing. (Sometimes this is referred to as \"extended slicing\".) Remember that Python uses zero-based indexing!"
    ]
   },
   {
@@ -1654,7 +1658,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The previous change to the NumPy notebook accidentally resulted in invalid notebook json (inline double-quotes that were not escaped), which this change fixes.