### PR TITLE
Shorten NumPy course

### DIFF
--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -711,7 +711,7 @@
     "\n",
     "There are times when you need to perform calculations between NumPy arrays of different sizes. NumPy allows you to do this easily using a powerful piece of functionality called **broadcasting**.\n",
     "\n",
-    "Broadcasting is a way of treating the arrays as if they had the same dimensions, and thus have elements all corresponding.  It is then easy to perform the calculation, element-wise. It does this by matching dimensions in one array to the other where possible, and using repeated values where there is no corresponding dimension in the other array."
+    "Broadcasting is a way of treating the arrays as if they had the same dimensions and thus have elements all corresponding.  It is then easy to perform the calculation, element-wise. It does this by matching dimensions in one array to the other where possible, and using repeated values where there is no corresponding dimension in the other array."
    ]
   },
   {
@@ -973,7 +973,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that most file formats represent missing data in a _different_ way, using a distinct \"missing data\" value appearing in the data. There is special support for converting between this type of representation and NumPy masked arrays. Every masked array has a 'fill_value' property and a 'filled()' method to convert between the two."
+    "Note that most file formats represent missing data in a _different_ way, using a distinct \"missing data\" value appearing in the data. There is special support for converting between this type of representation and NumPy masked arrays. Every masked array has a `fill_value` property and a `filled()` method to fill the masked points with the fill value."
    ]
   },
   {

--- a/course_content/notebooks/numpy_intro.ipynb
+++ b/course_content/notebooks/numpy_intro.ipynb
@@ -709,85 +709,17 @@
    "source": [
     "### Broadcasting\n",
     "\n",
-    "There are times when you need to perform calculations between NumPy arrays of different sizes.\n",
+    "There are times when you need to perform calculations between NumPy arrays of different sizes. NumPy allows you to do this easily using a powerful piece of functionality called **broadcasting**.\n",
     "\n",
-    "For example, suppose you have maximum temperatures from each of three recording stations, recorded on two separate days."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "daily_records = np.array([[12, 14, 11], [11, 12, 15]])\n",
-    "\n",
-    "print('raw data:')\n",
-    "print(daily_records)"
+    "Broadcasting is a way of treating the arrays as if they had the same dimensions, and thus have elements all corresponding.  It is then easy to perform the calculation, element-wise. It does this by matching dimensions in one array to the other where possible, and using repeated values where there is no corresponding dimension in the other array."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Each station is known to overstate the maximum recorded temperature by a different known constant value. You wish to subtract the appropriate offset from each station's values.\n",
+    "#### Rules of Broadcasting\n",
     "\n",
-    "You can do that like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "internals": {
-     "slide_helper": "subslide_end"
-    },
-    "slide_helper": "slide_end",
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "offset = np.array([2, 1, 4])\n",
-    "\n",
-    "corrected_records = daily_records - offset\n",
-    "\n",
-    "print('corrected values:')\n",
-    "print(corrected_records)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "NumPy allows you to do this easily using a powerful piece of functionality called **broadcasting**."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "internals": {},
-    "slideshow": {
-     "slide_type": "-"
-    }
-   },
-   "source": [
-    "Broadcasting is a way of treating the arrays ***as if*** they had the same dimensions, and thus have elements all corresponding.  It is then easy to perform the calculation, element-wise.  \n",
-    "It does this by matching dimensions in one array to the other where possible, and using repeated values where there is no corresponding dimension in the other array."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Rules of Broadcasting"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Broadcasting applies these three rules:\n",
     "\n",
     "1.    If the two arrays differ in their number of dimensions, the shape of the array with fewer dimensions is padded with ones on its leading (left) side.\n",
@@ -882,90 +814,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now suppose you want to apply a correction for each day.\n",
+    "#### Exercise, continued\n",
     "\n",
-    "For example, you might try :\n"
+    "For the failing example above, what reshape operation could you apply to `arr2` so that it can be broadcast with `arr1`?"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "days_adjust = np.array([1.5, 3.7])\n",
-    "adjusted = daily_records - days_adjust"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "but that results in a `ValueError`. Clearly, this doesn't work !"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Exercise\n",
-    "\n",
-    "With reference to the above rules of broadcasting:\n",
-    " 1. describe why the above attempt to subtract `days_adjust` fails\n",
-    " 1. work out how you can modify the 'days_adjust' array to get the desired result.  \n",
-    "    Hint: imagine how the 'days_adjust' values *should* look, when expanded to match the dimensions of 'daily_records'."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Exercise \n",
-    "\n",
-    "Sometimes an operation will produce a result, but not the one you wanted.\n",
-    "\n",
-    "For example, suppose we have :\n",
-    "```python\n",
-    "A = np.array([[1, 2, 3],\n",
-    "              [4, 5, 6],\n",
-    "              [7, 8, 9]])\n",
-    "```\n",
-    "\n",
-    "and we wish to add 0, 100 and 400 ***to the rows***.\n",
-    "That is,\n",
-    "\n",
-    "```python\n",
-    "B = np.array([0, 100, 400])\n",
-    "# and...\n",
-    "desired_result = np.array([[  1,   2,   3],\n",
-    "                           [104, 105, 406],\n",
-    "                           [407, 408, 409]])\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "##### Questions:\n",
-    "\n",
-    " 1. What will be the result of adding A to B directly?\n",
-    " 1. How can you perform the correct calculation on `A` and `B` to get `desired_result`?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -1024,26 +876,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Used without any further arguments, statistical functions simply reduce the whole array to a single value.  In practice, however, we very often want to calculate statistics over only *some* of the dimensions.\n",
+    "Used without any further arguments, statistical functions simply reduce the whole array to a single value.  In practice, however, we very often want to calculate statistics over only *some* of the dimensions. The most common requirement is to calculate a statistic along a single array dimension, while leaving all the other dimensions intact.   This is referred to as \"collapsing\" or \"reducing\" the chosen dimension.\n",
     "\n",
-    "The most common requirement is to calculate a statistic along a single array dimension, while leaving all the other dimensions intact.   This is referred to as \"collapsing\" or \"reducing\" the chosen dimension.\n",
-    "\n",
-    "This is done by adding an \"axis\" keyword specifying which dimension, such as `np.min(data, axis=1)`. \n",
-    "\n",
-    "For example, recall that the above \"daily_records\" data varies over 2 timepoints and 3 locations, mapped to array dimensions 0 and 1 respectively:\n",
-    "\n",
-    "```python\n",
-    "print(daily_records)\n",
-    "[[12 14 11]\n",
-    " [11 12 15]]\n",
-    "```\n",
-    "\n",
-    "For this data, by adding the `axis` keyword, we can calculate either...\n",
-    "  * using `axis=0`: a statistic **over both days, for each station**, or\n",
-    "  * using `axis=1`: a statistic **over all three stations, for each day**.\n",
-    "\n",
-    "For most statistical functions (but not all), the \"axis\" keyword will also accept multiple dimensions, e.g. `axis=(0, 2)`.  \n",
-    "Remember also that the *default* statistical operation, as seen above, is to collapses over _all_ dimensions, reducing the array to a single value.  This is equivalent to specifying `axis=None`."
+    "This is done by adding an \"axis\" keyword specifying the dimension to collapse:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(np.mean(a, axis=1))"
    ]
   },
   {
@@ -1054,12 +898,8 @@
     "\n",
     "* What other similar statistical operations exist (see above link)?\n",
     "* A mean value can also be calculated with `<array>.mean()`.  Is that the same thing?\n",
-    "* produce the two kinds of single-axis average mentioned above -- that is:\n",
-    "   1. over all days at each station, \n",
-    "   2. over all stations for each day.\n",
-    "* Create a sample 3-D array (for example, this could represent air temperature at given [time, X, Y] positions):\n",
-    "   1. how can you form a mean over all X and Y at each timestep?  \n",
-    "   1. what shape does the result have?"
+    "* Create a 3D array (that could be considered to describe `[time, x, y]`) and find the mean over all `x` and `y` at each timestep.\n",
+    "* What shape does the result have?"
    ]
   },
   {
@@ -1091,10 +931,9 @@
     "\n",
     "Real-world measurements processes often result in certain datapoint values being uncertain or simply \"missing\".  This is usually indicated by additional data quality information, stored alongside the data values.\n",
     "\n",
-    "In these cases we often need to make calculations that count only the ***valid*** datapoints.  NumPy provides a special \"masked array\" type for this type of calculation. Here's a link to the documentation for NumPy masked arrays: https://docs.scipy.org/doc/numpy-1.11.0/reference/maskedarray.generic.html#maskedarray-generic-constructing.\n",
+    "In these cases we often need to make calculations that count only the valid datapoints.  NumPy provides a special \"masked array\" type for this type of calculation. Here's a link to the documentation for NumPy masked arrays: https://docs.scipy.org/doc/numpy-1.11.0/reference/maskedarray.generic.html#maskedarray-generic-constructing.\n",
     "\n",
-    "For example, we might know that in our previous `daily_records` data, the value for station-2 on day-1 is invalid.\n",
-    "To represent this missing datapoint, we can make a masked version of the data :"
+    "To construct a masked array we need some data and a mask. The data can be any kind of NumPy array, but the mask array must contain a boolean-type values only (either `True` and `False` or `1` and `0`). Let's make each of these and convert them together into a NumPy masked array:"
    ]
   },
   {
@@ -1103,18 +942,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "daily_records = np.array([[12, 14, 11], [11, 12, 15]])\n",
-    "masked_data = np.ma.masked_array(daily_records)\n",
-    "masked_data[0, 1] = np.ma.masked\n",
-    "print('masked data:')\n",
-    "print(masked_data)"
+    "data = np.arange(4)\n",
+    "mask = np.array([0, 0, 1, 0])\n",
+    "print('Data: {}'.format(data))\n",
+    "print('Mask: {}'.format(mask))\n",
+    "masked_data = np.ma.masked_array(data, mask)\n",
+    "print('Masked data: {}'.format(masked_data))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The statistics of the masked data version are different:"
+    "The mask is applied where the values in the mask array are **`True`**. Masked arrays are printed with a double-dash `--` denoting the locations in the array where the mask has been applied.\n",
+    "\n",
+    "The statistics of masked data are different:"
    ]
   },
   {
@@ -1123,21 +965,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('unmasked average = ', np.mean(daily_records))\n",
-    "print('masked average = ', np.ma.mean(masked_data))"
+    "print('Unmasked average: {}'.format(np.mean(data)))\n",
+    "print('Masked average: {}'.format(np.ma.mean(masked_data)))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `np.ma.masked_array()` function seen above is a simple creation method for masked data.  \n",
-    "The sub-module `np.ma` contains all the NumPy masked-data routines.\n",
-    "\n",
-    "Instead of masking selected points, as above, a mask is often specified as a \"mask array\":  This is a boolean array of the same size and shape as the data, where `False` means a good datapoint and `True` means a masked or missing point.  Such a 'boolean mask' can be passed in the `np.ma.masked_array` creation method, and can be extracted with the `np.ma.getmaskarray()` function.\n",
-    "\n",
-    "Note that most file storage formats represent missing data in a _different_ way, using a distinct \"missing data\" value appearing in the data.  \n",
-    "There is special support for converting between this type of representation and NumPy masked arrays :  Every masked array has a 'fill_value' property and a 'filled()' method to convert between the two."
+    "Note that most file formats represent missing data in a _different_ way, using a distinct \"missing data\" value appearing in the data. There is special support for converting between this type of representation and NumPy masked arrays. Every masked array has a 'fill_value' property and a 'filled()' method to convert between the two."
    ]
   },
   {


### PR DESCRIPTION
Shorten the NumPy course by removing the "observing site" content. Good as this content was for making NumPy real-world applicable, in practice it just made the course too long to teach. As such, I've stripped the content out but retained the generic teaching embedded in the content.