### PR TITLE
Host notebooks on BinderHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ particularly in the fields of oceanography and meteorology.
 There are currently four courses:
 
 ### An introduction to numpy
-3.5 hours &mdash; depends on a basic Python background  
+3.5 hours &mdash; depends on a basic Python background\
 https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Fnumpy_intro.ipynb
 
 ### An introduction to matplotlib
-3 hours &mdash; depends on "An introduction to numpy"  
+3 hours &mdash; depends on "An introduction to numpy"\
 https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Fmatplotlib_intro.ipynb
 
 ### Cartopy in a nutshell (for Iris)
-0.5 hours &mdash; depends on "An introduction to matplotlib"  
+0.5 hours &mdash; depends on "An introduction to matplotlib"\
 https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Fcartopy_intro.ipynb
 
 ### An introduction to Iris
-6 hours &mdash; depends on "Cartopy in a nutshell"  
+6 hours &mdash; depends on "Cartopy in a nutshell"\
 https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Firis_intro.ipynb

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ particularly in the fields of oceanography and meteorology.
 There are currently four courses:
 
 ### An introduction to numpy
-3.5 hours &mdash; depends on a basic Python background
-http://nbviewer.ipython.org/github/SciTools/courses/blob/master/course_content/notebooks/numpy_intro.ipynb?create=1
+3.5 hours &mdash; depends on a basic Python background  
+https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Fnumpy_intro.ipynb
 
 ### An introduction to matplotlib
-3 hours &mdash; depends on "An introduction to numpy"
-http://nbviewer.ipython.org/github/SciTools/courses/blob/master/course_content/notebooks/matplotlib_intro.ipynb?create=1
+3 hours &mdash; depends on "An introduction to numpy"  
+https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Fmatplotlib_intro.ipynb
 
 ### Cartopy in a nutshell (for Iris)
-0.5 hours &mdash; depends on "An introduction to matplotlib"
-http://nbviewer.ipython.org/github/SciTools/courses/blob/master/course_content/notebooks/cartopy_intro.ipynb?create=1
+0.5 hours &mdash; depends on "An introduction to matplotlib"  
+https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Fcartopy_intro.ipynb
 
 ### An introduction to Iris
-6 hours &mdash; depends on "Cartopy in a nutshell"
-http://nbviewer.ipython.org/github/SciTools/courses/blob/master/course_content/notebooks/iris_intro.ipynb?create=1
+6 hours &mdash; depends on "Cartopy in a nutshell"  
+https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fnotebooks%2Firis_intro.ipynb

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: courses
+name: scitools-courses
 channels:
   - conda-forge
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: courses
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - numpy
+  - matplotlib
+  - cartopy
+  - iris

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - matplotlib
   - cartopy
   - iris
+  - iris-sample-data

--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - cartopy
   - iris
   - iris-sample-data
+  - nc-time-axis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.15.4
+matplotlib==3.0.2
+cartopy==0.17.0
+iris==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy==1.15.4
-matplotlib==3.0.2
-cartopy==0.16.0
-iris==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.15.4
 matplotlib==3.0.2
-cartopy==0.17.0
+cartopy==0.16.0
 iris==2.2.0


### PR DESCRIPTION
## Problem
Currently the links in README.md only point to a static html version of the notebooks using nbviewer.

## Solution
This PR adds an `environment.yml` to allow Binder to create a Docker image from which to run the notebooks. These are fully interactive and editable so that those wishing to learn from the courses can do so without having to worry about setting up and running the notebooks on a local machine.

#### NB: Links in this PR's README.md point to `SciTools/courses/master` so will not produce a fully working notebook until this PR is merged.