### PR TITLE
Split Iris course into multiple notebooks  + improve first two sections

### DIFF
--- a/course_content/notebooks/iris_course/0.Iris_Course_Intro.ipynb
+++ b/course_content/notebooks/iris_course/0.Iris_Course_Intro.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# An Introduction to Iris\n",
+    "## Course Intro "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This course is intended as a beginners course."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Course Aim\n",
+    "\n",
+    "The aim of this course is to introduce Iris and its main features and functionality, with a focus on how these relate to data analysis.\n",
+    "\n",
+    "The course will cover:\n",
+    "1. [The Iris Cube](1.The_Iris_Cube.ipynb)\n",
+    "2. [Loading and Saving Data](2.Loading_and_Saving.ipynb)\n",
+    "3. [Cube Control and Subsetting](#cube_control_and_subsetting)\n",
+    "4. [Data Processing](#data_processing)\n",
+    "5. [Advanced Concepts](#advanced_concepts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.2.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import iris\n",
+    "print(iris.__version__)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/course_content/notebooks/iris_course/1.The_Iris_Cube.ipynb
+++ b/course_content/notebooks/iris_course/1.The_Iris_Cube.ipynb
@@ -1,0 +1,783 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 1. The Iris Cube\n",
+    "\n",
+    "**Learning Outcome**: by the end of this section, you will be able to explain the capabilities and functionality of Iris Cubes and Coordinates.\n",
+    "\n",
+    "**Duration:** 1.5 hour\n",
+    "\n",
+    "**Overview:**<br>\n",
+    "1.1 [Introduction to the Iris Cube](#intro_to_iris_cube)<br>\n",
+    "1.2 [Working with a Cube](#working_with_a_cube)<br>\n",
+    "1.3 [Cube Attributes](#cube_attributes)<br>\n",
+    "1.4 [Coordinates](#coordinates)<br>\n",
+    "1.5 [Exercise](#exercise)<br>\n",
+    "1.6 [Summary of the Section](#summary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import iris"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 1.1 Introduction to the Iris Cube<a id='intro_to_iris_cube'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top level object in Iris is called a Cube. A Cube contains data and metadata about a single phenomenon and is an implementation of the data model interpreted from the *Climate and Forecast (CF) Metadata Conventions*.\n",
+    "\n",
+    "Each cube has:\n",
+    "\n",
+    " * A data array (typically a NumPy array).\n",
+    " * A \"name\", preferably a CF \"standard name\" to describe the phenomenon that the cube represents.\n",
+    " * A collection of coordinates to describe each of the dimensions of the data array. These coordinates are split into two types:\n",
+    "    * Dimension Coordinates are numeric, monotonic and represent a single dimension of the data array. There may be only one Dimension Coordinate per data dimension.\n",
+    "    * Auxilliary Coordinates can be of any type, including discrete values such as strings, and may represent more than one data dimension.\n",
+    "\n",
+    "A fuller explanation is available in the [Iris user guide](http://scitools.org.uk/iris/docs/latest/userguide/iris_cubes.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a simple example to demonstrate the Cube concept.\n",
+    "\n",
+    "Suppose we have a ``(3, 2, 4)`` NumPy array:\n",
+    "\n",
+    "![](../../images/multi_array.png)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Where dimensions 0, 1, and 2 have lengths 3, 2 and 4 respectively.\n",
+    "\n",
+    "The Iris Cube to represent this data may consist of:\n",
+    "\n",
+    " * a standard name of \"air_temperature\" and units of \"kelvin\"\n",
+    "\n",
+    " * a data array of shape ``(3, 2, 4)``\n",
+    "\n",
+    " * a coordinate, mapping to dimension 0, consisting of:\n",
+    "     * a standard name of \"height\" and units of \"meters\"\n",
+    "     * an array of length 3 representing the 3 height points\n",
+    "     \n",
+    " * a coordinate, mapping to dimension 1, consisting of:\n",
+    "     * a standard name of \"latitude\" and units of \"degrees\"\n",
+    "     * an array of length 2 representing the 2 latitude points\n",
+    "     * a coordinate system such that the latitude points could be fully located on the globe\n",
+    "     \n",
+    " * a coordinate, mapping to dimension 2, consisting of:\n",
+    "     * a standard name of \"longitude\" and units of \"degrees\"\n",
+    "     * an array of length 4 representing the 4 longitude points\n",
+    "     * a coordinate system such that the longitude points could be fully located on the globe"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pictorially the Cube has taken on more information than a simple array:\n",
+    "\n",
+    "![](../../images/multi_array_to_cube.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "-----\n",
+    "\n",
+    "## 1.2 Working with a Cube<a id='working_with_a_cube'></a>\n",
+    "\n",
+    "To load in a Cube from a file, we make use of the [iris.load](https://scitools.org.uk/iris/docs/latest/iris/iris.html#iris.load) function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>Take a look at the above link to see how `iris.load` is called.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the purpose of this course, we will be using the sample data provided with Iris. We use the utility function [iris.sample_data_path](https://scitools.org.uk/iris/docs/latest/iris/iris.html#iris.sample_data_path) which returns the _filepath_ of where the sample data is installed. We assign the output filepath returned by the `iris.sample_data_path` function to a variable called `fname`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = iris.sample_data_path('space_weather.nc')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>Try printing fname to see where the sample data is installed on your system.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We load in the filepath with `iris.load`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: total electron content / (1E16 e/m^2) (grid_latitude: 31; grid_longitude: 31)\n",
+      "1: electron density / (1E11 e/m^3)     (height: 29; grid_latitude: 31; grid_longitude: 31)\n"
+     ]
+    }
+   ],
+   "source": [
+    "cubes = iris.load(fname)\n",
+    "print(cubes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`iris.load` returns an `iris.cube.CubeList` of all the cubes found in the file. From the above print out, we can see that we have loaded two cubes from the file, one representing the \"total electron content\" and the other representing \"electron density\". We can infer further detail about the returned cubes from this printout, such as the units, dimensions and shape."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b> What are the dimensions of the \"total electron content\" cube? What are the units of the \"electron_density\" cube?\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see more detail about a specific cube, we can print out a single cube from the cubelist. We can select the second cube in the cubelist with indexing, and then print out what it returns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electron density / (1E11 e/m^3)     (height: 29; grid_latitude: 31; grid_longitude: 31)\n",
+      "     Dimension coordinates:\n",
+      "          height                           x                  -                   -\n",
+      "          grid_latitude                    -                  x                   -\n",
+      "          grid_longitude                   -                  -                   x\n",
+      "     Auxiliary coordinates:\n",
+      "          latitude                         -                  x                   x\n",
+      "          longitude                        -                  x                   x\n",
+      "     Attributes:\n",
+      "          Conventions: CF-1.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "air_pot_temp = cubes[1]\n",
+    "print(air_pot_temp)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, we have an overview of the cube's dimensions as well as the cube's name and units. We also have further detail on the cube's metadata, such as the Dimension Coordinates, Auxiliary Coordinates and Attributes. \n",
+    "\n",
+    "In the printout, the dimension marker 'x' shows which dimensions apply to each coordinate. For example, we can see that the `latitude` Auxiliary Coordinate varies along the `grid_latitude` _and_ `grid_longitude` dimensions.\n",
+    "\n",
+    "Whilst the printout of a cube gives a nice overview of the cube's metadata, we can dig deeper by inspecting the attributes of our cube object, as covered in the next section."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "-----\n",
+    "\n",
+    "## 1.3 Cube Attributes<a id='cube_attributes'></a>\n",
+    "We load in a different file (using the `iris.sample_data_path` utility function, as before, to give us the path of the file) and index out the first cube from the cubelist that is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "air_temperature / (K)               (time: 240; latitude: 37; longitude: 49)\n",
+      "     Dimension coordinates:\n",
+      "          time                           x              -              -\n",
+      "          latitude                       -              x              -\n",
+      "          longitude                      -              -              x\n",
+      "     Auxiliary coordinates:\n",
+      "          forecast_period                x              -              -\n",
+      "     Scalar coordinates:\n",
+      "          forecast_reference_time: 1859-09-01 06:00:00\n",
+      "          height: 1.5 m\n",
+      "     Attributes:\n",
+      "          Conventions: CF-1.5\n",
+      "          Model scenario: A1B\n",
+      "          STASH: m01s03i236\n",
+      "          source: Data from Met Office Unified Model 6.05\n",
+      "     Cell methods:\n",
+      "          mean: time (6 hour)\n"
+     ]
+    }
+   ],
+   "source": [
+    "fname = iris.sample_data_path('A1B_north_america.nc')\n",
+    "cubes = iris.load(fname)\n",
+    "cube = cubes[0]\n",
+    "print(cube)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that we have loaded and selected an `air_temperature` cube with `time`, `latitude` and `longitude` dimensions and the associated Dimension coordinates. We also have a `forecast_period` Auxiliary coordinate which maps the time dimension. Our cube also has two scalar coordinates: `forecast_reference_time` and `height`, and a cell method of `mean: time (6 hour)` which means that the cube contains 6-hourly mean air temperatures."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access the values of air temperature in the cube we use the ``data`` property. This is either a NumPy array or, in some cases, a NumPy masked array. It is very important to note that for most of the supported filetypes in Iris, the cube's data isn't actually loaded until you request it via this property (either directly or indirectly). After you've accessed the data once, it is stored on the cube and thus won't be loaded from disk again.\n",
+    "\n",
+    "To find the shape of a cube's data it is possible to call ``cube.data.shape`` or ``cube.data.ndim``, but this will trigger any unloaded data to be loaded. Therefore ``shape`` and ``ndim`` are properties available directly on the cube that do not unnecessarily load data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(240, 37, 49)\n",
+      "3\n",
+      "<class 'numpy.ma.core.MaskedArray'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cube.shape)\n",
+    "print(cube.ndim)\n",
+    "print(type(cube.data))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>From the above output we can see that cube.data is a masked numpy array. How would you find out the fill value of this masked array?\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``standard_name``, ``long_name`` and to an extent ``var_name`` are all attributes to describe the phenomenon that the cube represents. The ``name()`` method is a convenience that looks at the name attributes in the order they are listed above, returning the first non-empty string. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "air_temperature\n",
+      "None\n",
+      "air_temperature\n",
+      "air_temperature\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cube.standard_name)\n",
+    "print(cube.long_name)\n",
+    "print(cube.var_name)\n",
+    "print(cube.name())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`standard_name` is restricted to be a CF standard name (see the [CF standard name table](http://cfconventions.org/standard-names.html)). If there is not a suitable CF standard name, `cube.standard name` is set to `None` and the `long_name` is used instead. `long_name` is less restrictive and can be set to be any string. `var_name` is less commonly required and is used to help distinguish the phenomena.\n",
+    "\n",
+    "To rename a cube, it is possible to set the attributes manually, but it is generally easier to use the ``rename()`` method.\n",
+    "\n",
+    "Below we rename the cube to a string that we know is not a valid CF standard name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cube.rename(\"A name that isn't a valid CF standard name\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "None\n",
+      "A name that isn't a valid CF standard name\n",
+      "None\n",
+      "A name that isn't a valid CF standard name\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cube.standard_name)\n",
+    "print(cube.long_name)\n",
+    "print(cube.var_name)\n",
+    "print(cube.name())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When renaming a cube, Iris will initally try to set `cube.standard_name`. IF the name is not a standard name, `cube.long_name` is set instead."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>Take a look at the [CF standard name table](http://cfconventions.org/standard-names.html) and try renaming the cube to the an accepted name.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``units`` attribute on a cube tells us the units of the numbers held in the data array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "K\n",
+      "306.0733\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cube.units)\n",
+    "print(cube.data.max())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can convert the cube to another unit using the ``convert_units`` method, which will automatically update the data array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Celsius\n",
+      "32.9233\n"
+     ]
+    }
+   ],
+   "source": [
+    "cube.convert_units('Celsius')\n",
+    "print(cube.units)\n",
+    "print(cube.data.max())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A cube has a dictionary for extra general purpose attributes, which can be accessed with the ``cube.attributes`` attribute:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Conventions': 'CF-1.5', 'STASH': STASH(model=1, section=3, item=236), 'Model scenario': 'A1B', 'source': 'Data from Met Office Unified Model 6.05'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cube.attributes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>Update the `cube.attributes` dictionary with a new entry, for example <pre>{'comment':'Original data had units of degrees celsius'}</pre>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 1.4 Coordinates<a id='coordinates'></a>\n",
+    "\n",
+    "As we've seen, cubes need coordinate information to help us describe the underlying phenomenon. Typically a cube's coordinates are accessed with the ``coords`` or ``coord`` methods. The latter *must* return exactly one coordinate for the given parameter filters, where the former returns a list of matching coordinates, possibly of length 0.\n",
+    "\n",
+    "For example, to access the time coordinate, and print the first 4 times:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DimCoord([1860-06-01 00:00:00, 1861-06-01 00:00:00, 1862-06-01 00:00:00,\n",
+      "       1863-06-01 00:00:00], bounds=[[1859-12-01 00:00:00, 1860-12-01 00:00:00],\n",
+      "       [1860-12-01 00:00:00, 1861-12-01 00:00:00],\n",
+      "       [1861-12-01 00:00:00, 1862-12-01 00:00:00],\n",
+      "       [1862-12-01 00:00:00, 1863-12-01 00:00:00]], standard_name='time', calendar='360_day', var_name='time')\n"
+     ]
+    }
+   ],
+   "source": [
+    "time = cube.coord('time')\n",
+    "print(time[:4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The coordinate interface is very similar to that of a cube. The attributes that exist on both cubes and coordinates are: ``standard_name``, ``long_name``, ``var_name``, ``units``, ``attributes`` and ``shape``. Similarly, the ``name()``, ``rename()`` and ``convert_units()`` methods also exist on a coordinate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A coordinate does not have ``data``, instead it has ``points`` and ``bounds`` (``bounds`` may be ``None``). In Iris, time coordinates are currently represented as \"a number since an epoch\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unit('hours since 1970-01-01 00:00:00', calendar='360_day')\n",
+      "[-946800. -938160. -929520. -920880.]\n",
+      "[[-951120. -942480.]\n",
+      " [-942480. -933840.]\n",
+      " [-933840. -925200.]\n",
+      " [-925200. -916560.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(repr(time.units))\n",
+    "print(time.points[:4])\n",
+    "print(time.bounds[:4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These numbers can be converted to datetime objects with the unit's ``num2date`` method. Dates can be converted back again with the ``date2num`` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[cftime._cftime.Datetime360Day(1860, 6, 1, 0, 0, 0, 0, -1, 151)\n",
+      " cftime._cftime.Datetime360Day(1861, 6, 1, 0, 0, 0, 0, -1, 151)\n",
+      " cftime._cftime.Datetime360Day(1862, 6, 1, 0, 0, 0, 0, -1, 151)\n",
+      " cftime._cftime.Datetime360Day(1863, 6, 1, 0, 0, 0, 0, -1, 151)]\n",
+      "720.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import datetime\n",
+    "\n",
+    "print(time.units.num2date(time.points[:4]))\n",
+    "print(time.units.date2num(datetime.datetime(1970, 2, 1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another important attribute on a coordinate is its coordinate system. Coordinate systems may be ``None`` for trivial coordinates, but particularly for spatial coordinates, they may be complex definitions of things such as the projection, ellipse and/or datum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GeogCS(6371229.0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "lat = cube.coord('latitude')\n",
+    "print(lat.coord_system)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, the latitude's coordinate system is a simple geographic latitude on a spherical globe of radius 6371229 (meters)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 1.5 Exercise 1<a id='exercise'></a>\n",
+    "\n",
+    "1\\. Load the file in ``iris.sample_data_path('atlantic_profiles.nc')`` and print the cube list. Store these cubes in a variable called `cubes`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2\\. Loop through each of the cubes (e.g. ``for cube in cubes``) and print the standard name of each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3\\. Index `cubes` to retrieve the `sea_water_potential_temperature` cube. \n",
+    "Note: that indexing to extract single cubes is useful for EDA, but it is better practice to use constraints (See [3. Cube Control and Subsetting.ipynb](#3.Cube_Control_and_Subsetting.ipynb) for more information)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "4\\. Get hold of the `latitude` coordinate on the `sea_water_potential_temperature` cube. Identify whether this coordinate has bounds. Print the minimum and maximum latitude points in the cube."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Exercise Solutions: \n",
+    "Once you are happy with your answers, you can check the solutions by runnning the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load ../../solutions/iris_exercise_1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 1.6 Summary of Section: The iris Cube<a id='summary'></a>\n",
+    "\n",
+    "In this section we learnt:\n",
+    "* An iris cube, which contains data and metadata, is based on the cf data model, containing dimension and auxiliary coordinates.\n",
+    "* Printing out a cube gives an overview of its metadata. We can get more information on the cube by inspecting its attributes (e.g. `cube.standard_name`, `cube.units()`)\n",
+    "* A coordinate has a similar interface to a cube, but a coordinate has points and bounds, where a cube has data."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/course_content/notebooks/iris_course/2.Loading_and_Saving.ipynb
+++ b/course_content/notebooks/iris_course/2.Loading_and_Saving.ipynb
@@ -1,0 +1,412 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 2. Loading and Saving\n",
+    "\n",
+    "**Learning Outcome**: by the end of this section, you will be able to use Iris to load datasets from disk as Iris cubes and save Iris cubes back to disk.\n",
+    "\n",
+    "**Duration:** 1 hour\n",
+    "\n",
+    "**Overview:**<br>\n",
+    "2.1 [Iris Load Functions](#iris_load_functions)<br>\n",
+    "2.2 [Saving Cubes](#saving)<br>\n",
+    "2.3 [Out-of-core Processing](#out_of_core_processing)<br>\n",
+    "2.4 [Exercise](#exercise_2)<br>\n",
+    "2.5 [Summary of the Section](#summary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import iris"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 2.1 Iris Load Functions<a id='iris_load_functions'></a>\n",
+    "\n",
+    "There are three main load functions in Iris: ``load``, ``load_cube`` and ``load_cubes``.\n",
+    "\n",
+    "1. **load** is a general purpose loading function. Typically this is where all data analysis will start, before more loading is refined with the more controlled loading from the other two functions.\n",
+    "2. **load_cube** returns a single cube from the given source(s) and constraint. There will be exactly one cube, or an exception will be raised.\n",
+    "3. **load_cubes** returns a cubelist of cubes from the given sources(s) and constraint(s). There will be exactly one cube per constraint, or an exception will be raised.\n",
+    "\n",
+    "\n",
+    "Note: ``load_cube`` is a special case of ``load``. \n",
+    "\n",
+    "Let's compare the result of calling `load` and `load_cube`. We start by selecting the `air_temp.pp` file from Iris' sample data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = iris.sample_data_path('air_temp.pp')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we give this filepath to `load`, we see that Iris returns a cubelist."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'iris.cube.CubeList'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "c1 = iris.load(fname)\n",
+    "print(type(c1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If instead we give this filepath to `iris.load_cube` we see that Iris a cube."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'iris.cube.Cube'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "c2 = iris.load_cube(fname)\n",
+    "print(type(c2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we compare the first cube in the cubelist returned by calling `load` and the cube returned by calling `load_cube` we see that they are the equal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c1[0] == c2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>Try loading in the `uk_hires.pp` from Iris' sample data, first with iris.load then iris.load_cube. Why does iris.load_cube fail if you only supply the filepath?\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 2.2 Saving Cubes<a id='saving'></a>\n",
+    "\n",
+    "The [iris.save](https://scitools.org.uk/iris/docs/latest/iris/iris.html#iris.save) function provides a convenient interface to save Cube and CubeList instances.\n",
+    "\n",
+    "Below we load the `uk_hires.pp` file from Iris' provided sample data which returns a cubelist of the cubes that were produced from that file. We then save this cubelist out to netcdf."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fname = iris.sample_data_path('uk_hires.pp')\n",
+    "cubes = iris.load(fname)\n",
+    "iris.save(cubes, 'saved_cubes.nc')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check the ncdump to see what Iris saved:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "netcdf saved_cubes {\r\n",
+      "dimensions:\r\n",
+      "\ttime = 3 ;\r\n",
+      "\tmodel_level_number = 7 ;\r\n",
+      "\tgrid_latitude = 204 ;\r\n",
+      "\tgrid_longitude = 187 ;\r\n",
+      "\tbnds = 2 ;\r\n",
+      "variables:\r\n",
+      "\tfloat air_potential_temperature(time, model_level_number, grid_latitude, grid_longitude) ;\r\n",
+      "\t\tair_potential_temperature:standard_name = \"air_potential_temperature\" ;\r\n",
+      "\t\tair_potential_temperature:units = \"K\" ;\r\n",
+      "\t\tair_potential_temperature:um_stash_source = \"m01s00i004\" ;\r\n",
+      "\t\tair_potential_temperature:grid_mapping = \"rotated_latitude_longitude\" ;\r\n",
+      "\t\tair_potential_temperature:coordinates = \"forecast_period forecast_reference_time level_height sigma surface_altitude\" ;\r\n",
+      "\tint rotated_latitude_longitude ;\r\n",
+      "\t\trotated_latitude_longitude:grid_mapping_name = \"rotated_latitude_longitude\" ;\r\n",
+      "\t\trotated_latitude_longitude:longitude_of_prime_meridian = 0. ;\r\n",
+      "\t\trotated_latitude_longitude:earth_radius = 6371229. ;\r\n",
+      "\t\trotated_latitude_longitude:grid_north_pole_latitude = 37.5 ;\r\n",
+      "\t\trotated_latitude_longitude:grid_north_pole_longitude = 177.5 ;\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ncdump -h saved_cubes.nc | head -n 20\n",
+    "!rm saved_cubes.nc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Extra keywords can be passed to specific fileformat savers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Suggested Activity: </b>Take a look at the above link to the `iris.save` documentation to see what fileformats iris supports saving to.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "-----\n",
+    "\n",
+    "## 2.3 Out-of-core Processing<a id='out_of_core_processing'></a>\n",
+    "\n",
+    "[Out-of-core processing](https://en.wikipedia.org/wiki/External_memory_algorithm) is a technical term that describes being able to process datasets that are too large to fit in memory at once. In Iris, this functionality is referred to as **lazy data**. It means that you can use Iris to load, process and save datasets that are too large to fit in memory without running out of memory. This is achieved by loading only the dataset's metadata and not the data array, unless this is specifically requested.\n",
+    "\n",
+    "To determine whether your cube has lazy data you can use the `has_lazy_data` method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "fname = iris.sample_data_path('air_temp.pp')\n",
+    "cube = iris.load_cube(fname)\n",
+    "print(cube.has_lazy_data())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Iris tries to maintain lazy data as much as possible. We refer to the operation of loading a cube's lazy data as 'realising' the cube's data. A cube's lazy data will only be loaded in a limited number of cases, including:\n",
+    "\n",
+    "* when the user directly requests the cube's data using `cube.data`,\n",
+    "* when there is no lazy data processing algorithm available to perform the requested data processing, such as for peak finding, and\n",
+    "* where actual data values are necessary, such as for cube plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "cube.data\n",
+    "print(cube.has_lazy_data())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Above we have triggered the data to be loaded into memory by calling `cube.data`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "\n",
+    "## 2.4 Exercise 2<a id='exercise_2'></a>\n",
+    "\n",
+    "1\\. Load the file in `iris.sample_data_path('atlantic_profiles.nc')`, as in Exercise 1, but this time use `iris.load_cube` to load in the `sea_water_potential_temperature` cube only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2\\. Check whether this cube has lazy data? Print the minimum, maximum, mean and standard deviation of the cube's data. Does the cube still have lazy data?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3\\. Go to the Iris reference documentation for ``iris.save``. What keywords are accepted to ``iris.save`` when saving a PP file?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Exercise Solutions: \n",
+    "Once you are happy with your answers, you can check the solutions by runnning the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load ../../solutions/iris_exercise_2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "-----\n",
+    "\n",
+    "## 2.5 Summary of the Section: Loading and Saving<a id='summary'></a>\n",
+    "\n",
+    "In this section we learnt:\n",
+    "* Iris has different loading functions for different purposes, for example `iris.load` should be used for exploratory data analysis\n",
+    "* Iris supports saving to three fileformats: netCDF, GRIB2 and PP\n",
+    "* Iris uses lazy data and out-of-core-processing to handle data that it too large to fit into memory"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/course_content/solutions/iris_exercise_1
+++ b/course_content/solutions/iris_exercise_1
@@ -1,0 +1,18 @@
+# Solutions for Iris Exercise 1
+
+# Question 1
+fname = iris.sample_data_path('atlantic_profiles.nc')
+cubes = iris.load(fname)
+print(cubes)
+
+# Question 2
+for cube in cubes:
+    print(cube.standard_name)
+    
+# Question 3
+swpt_cube = cubes[0]
+
+# Question 4
+print(swpt_cube.coord('latitude').has_bounds())
+print(swpt_cube.coord('latitude').points.min())
+print(swpt_cube.coord('latitude').points.max())

--- a/course_content/solutions/iris_exercise_2
+++ b/course_content/solutions/iris_exercise_2
@@ -1,0 +1,28 @@
+# Solutions for Iris Exercise 2
+
+# Question 1
+fname = iris.sample_data_path('atlantic_profiles.nc')
+swpt_cube = iris.load_cube(fname, 'sea_water_potential_temperature')
+print(swpt_cube)
+
+# Question 2
+print(swpt_cube.has_lazy_data())
+print(swpt_cube.data.min())
+print(swpt_cube.data.max())
+print(swpt_cube.data.mean())
+print(swpt_cube.data.std())
+print(swpt_cube.has_lazy_data())
+    
+# Question 3
+```
+Reference documentation for iris.save:
+http://scitools.org.uk/iris/docs/latest/iris/iris.html?highlight=save#iris.save
+
+Keywords accepted:
+
+append
+Whether to start a new file afresh or add the cube(s) to the end of the file. Only applicable when target is a filename, not a file handle. Default is False.
+
+field_coords
+list of 2 coords or coord names which are to be used for reducing the given cube into 2d slices, which will ultimately determine the x and y coordinates of the resulting fields. If None, the final two dimensions are chosen for slicing.
+```


### PR DESCRIPTION
This PR includes three main additions:

* It demonstrates how we could split the iris course into multiple notebooks (a notebook per section), where each notebook includes a:
  * learning outcome
  * estimated duration
  * table of contents/notebook overview
  * exercise at the end of the notebook + multiple `suggested activity`s peppered throughout the notebook
  * a summary of what was learnt

* It demonstrates how we could use `%load` to reveal the solutions
* Added some improvements to the `The Iris Cube` and the `Loading and Saving` sections.

I have only focused on the first two sections/notebooks. I have not added any updates to the `coordinates` section in `The Iris Cube` as I believe @pp-mo was looking at that section.

