### PR TITLE
Fix dependencies for Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There are two main courses provided :
 ### An Introduction to Iris
 6 hours &mdash; depends on the "Cartopy in a nutshell" course:  
   * start from `course_content/iris_course/0.Iris_Course_Intro.ipynb`
-  * launch in binder [here](https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Firis_course)
+  * launch in binder [here](https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Firis_course%2F0.Iris_Course_Intro.ipynb)
 
 _Note: to run this course fully, you need to have installed_
 _not only iris and its dependencies,_

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,7 @@ name: scitools-courses
 channels:
   - conda-forge
 dependencies:
-  - python
-  - numpy
-  - matplotlib
-  - cartopy
+  - python<3.7
   - iris
   - iris-sample-data
   - nc-time-axis


### PR DESCRIPTION
Since numpy 1.16, we need Iris 2.2.1 so that the iris course code can load PP data successfully.
It seems this is struggling to resolve an env since the availablility of builds with Python3.7 (probably the matplotlib builds ?), so the latest Iris (2.2.1) is not installed + errors occur running in Binder.

Pinning Python seems the simplest way to fix this for now.
Also removed various dependencies that are implied by Iris itself.