### PR TITLE
Update cartopy course name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There are two main courses provided :
   * launch in binder [here](https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Fcartopy_course%2Fcartopy_intro.ipynb)
 
 ### An Introduction to Iris
-6 hours &mdash; depends on the "Cartopy in a nutshell" course:  
+6 hours &mdash; depends on the "First Look at Cartopy" course:  
   * start from `course_content/iris_course/0.Iris_Course_Intro.ipynb`
   * launch in binder [here](https://mybinder.org/v2/gh/SciTools/courses/master?filepath=course_content%2Firis_course%2F0.Iris_Course_Intro.ipynb)
 


### PR DESCRIPTION
It looks to me as if _Cartopy in a Nutshell_ doesn't exist any more.  So the Iris course prerequisite should be _A First Look at Cartopy_.